### PR TITLE
Docs: refine approach comparison table and terminology accuracy

### DIFF
--- a/aegis-core/architecture/AEGIS_Reference_Architecture.md
+++ b/aegis-core/architecture/AEGIS_Reference_Architecture.md
@@ -18,7 +18,7 @@ This design ensures that AI systems cannot directly execute operational actions 
 
 ---
 
-> **Architectural Layer Enforcement**: AEGIS operates at the architectural layer, enforcing policy at the execution boundary between AI agents and infrastructure. Unlike model-internal approaches (Constitutional Autonomy, RLHF), AEGIS is model-agnostic, deterministic, and federated. See [System Overview](../overview/AEGIS_System_Overview.md#architectural-positioning) for detailed positioning.
+> **Architectural Layer Enforcement**: AEGIS operates at the architectural layer, enforcing policy at the execution boundary between AI agents and infrastructure. Unlike model-internal approaches (Constitutional AI, RLHF, fine-tuning), AEGIS is model-agnostic, deterministic, and federated. See [System Overview](../overview/AEGIS_System_Overview.md#architectural-positioning) for detailed positioning.
 
 ---
 

--- a/aegis-core/overview/AEGIS_System_Overview.md
+++ b/aegis-core/overview/AEGIS_System_Overview.md
@@ -10,7 +10,8 @@ Effective Date: March 5, 2026
 
 # Overview
 
-AEGIS™ (Architectural Enforcement & Governance of Intelligent Systems) is a governance architecture designed to enforce deterministic control over AI-generated actions before those actions interact with operational infrastructure.
+AEGIS™ (Architec
+tural Enforcement & Governance of Intelligent Systems) is a governance architecture designed to enforce deterministic control over AI-generated actions before those actions interact with operational infrastructure.
 
 As AI systems become capable of executing real-world operations—querying databases, modifying infrastructure, triggering workflows, and interacting with APIs—the risks associated with ungoverned execution increase significantly. Traditional AI safety approaches focus primarily on influencing model behavior through alignment training and moderation. While valuable, those approaches do not guarantee that AI systems will act safely when given operational capabilities.
 
@@ -34,7 +35,7 @@ AEGIS operates at the **architectural layer**, enforcing policy at the execution
 
 **Architectural vs Model-Layer:**
 - **AEGIS** enforces policy *outside* the AI model, at the boundary between agents and infrastructure
-- **Model-internal approaches** (e.g., Constitutional Autonomy, RLHF) modify model weights, attention mechanisms, or training objectives
+- **Model-internal approaches** (e.g., Constitutional AI, RLHF, fine-tuning) modify model weights, attention mechanisms, or training objectives
 - AEGIS intercepts and validates agent actions *before* they reach external systems
 
 **Model-Agnostic:**
@@ -77,7 +78,10 @@ Several approaches exist, each with limitations:
 | Approach | Description | Limitations |
 |----------|-------------|-------------|
 | **Prompt Engineering** | Instruct AI models to "be careful" or "ask before acting" | Models may ignore prompts; adversarial prompts can override instructions |
-| **Model Alignment Training** | Train models to behave safely through RLHF and constitutional AI | Alignment is probabilistic, not deterministic; works for generation, not execution |
+| **RLHF (Human Feedback)** | Reinforcement learning from human preferences | Training-time only; probabilistic; expensive to scale; model-specific |
+| **Constitutional AI (Anthropic)** | Reinforcement learning from AI feedback (RLAIF) | Training-time only; probabilistic alignment; doesn't prevent execution |
+| **Output Filtering / Moderation** | Post-generation safety checks (OpenAI moderation, guardrails) | Acts after generation; doesn't govern execution; can be bypassed |
+| **Model Fine-tuning** | Safety-focused training (DPO, alignment techniques) | Probabilistic; model-specific; doesn't govern execution |
 | **Tool Restrictions** | Limit which tools AI can access | Coarse-grained; doesn't prevent misuse of allowed tools |
 | **Human-in-the-Loop** | Require human approval for every action | Doesn't scale; humans become bottlenecks and rubber-stamp approvals |
 | **Post-Execution Monitoring** | Detect problems after actions execute | Damage already done; too late for irreversible operations |

--- a/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
@@ -35,7 +35,7 @@ AEGIS enforces policy at the architectural layer—the boundary between AI agent
 - **Deterministic**: Guaranteed enforcement regardless of model behavior
 - **Federated**: Cross-organizational governance via GFN-1
 
-This contrasts with model-internal approaches (RLHF, Constitutional Autonomy) that modify model weights or attention mechanisms. AEGIS and model-layer approaches are complementary (defense-in-depth).
+This contrasts with model-internal approaches (Constitutional AI, RLHF, fine-tuning) that modify model weights or training objectives. AEGIS and model-layer approaches are complementary (defense-in-depth).
 
 ## Architecture Goals
 


### PR DESCRIPTION
## Summary

- Replace `Constitutional Autonomy` (uncited 2026 paper) with established terminology (`Constitutional AI`, `RLHF`, `fine-tuning`) across all three architectural positioning sections
- Expand Approach Comparison table from 6 to 9 rows, splitting out distinct model-layer approaches:
  - **RLHF (Human Feedback)** — reinforcement learning from human preferences
  - **Constitutional AI (Anthropic)** — RLAIF, technically distinct from RLHF
  - **Output Filtering / Moderation** — post-generation safety checks (new row)
  - **Model Fine-tuning** — DPO and alignment techniques

## Files changed

- `aegis-core/overview/AEGIS_System_Overview.md`
- `aegis-core/architecture/AEGIS_Reference_Architecture.md`
- `docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md`

## Test plan

- [ ] Verify table renders correctly in GitHub markdown preview
- [ ] Confirm no CI linting failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)