### PR TITLE
Docs: add outreach directory

### DIFF
--- a/docs/outreach/2026-03-constitutional-autonomy-outreach.md
+++ b/docs/outreach/2026-03-constitutional-autonomy-outreach.md
@@ -1,0 +1,78 @@
+# Outreach: Constitutional Autonomy Research Team
+**Date:** March 13, 2026\
+**From:** finnoybu@users.noreply.github.com\
+**To:** William Torgbi Agbemabiese\
+**Status:** Initial outreach sent\
+**Response:** Pending\
+**Discussion:** https://github.com/finnoybu/aegis-governance/discussions/39
+
+---
+
+## Email Sent
+
+William -
+
+I recently read your paper ["Toward Constitutional Autonomy in AI Systems"](https://ieeexplore.ieee.org/document/11354471) (IEEE Access 2026) and wanted to reach out regarding potential synergies between your work and a governance framework I've been developing.
+
+**Brief Introduction:** I'm Kenneth Tannenbaum, founder of the AEGIS™ Initiative. AEGIS (Architectural Enforcement & Governance of Intelligent Systems) is an open governance architecture for agentic AI systems, released under Apache 2.0 and submitted to NIST as a position paper for the AI Risk Management Framework.
+
+**Why I'm Reaching Out:** Your Constitutional Autonomy paper addresses governance inside the AI model through attention mechanism modification. AEGIS addresses governance outside the AI model at the architectural boundary between agents and infrastructure. I believe these approaches are highly complementary rather than competitive.
+
+**The Complementary Architecture:**
+
+- Constitutional Autonomy (model-layer): Shapes agent reasoning and behavior through constitutional attention weighting
+- AEGIS (architectural-layer): Enforces organizational policy deterministically at the execution boundary
+
+**Defense-in-Depth:** An ideal deployment would combine both layers:
+
+1. Constitutional Autonomy reduces the frequency of policy-violating proposals (model alignment)
+2. AEGIS prevents policy violations from executing even if the model is compromised (architectural enforcement)
+
+This multi-layer approach addresses a gap neither framework solves alone: Constitutional Autonomy provides probabilistic alignment; AEGIS provides deterministic enforcement.
+
+**Invitation for Public Discussion:** I've opened a discussion thread in the AEGIS GitHub repository specifically for this topic
+
+ - **GitHub Discussion:** https://github.com/finnoybu/aegis-governance/discussions/39
+
+I believe public technical discussion benefits the broader AI governance community. The thread covers:
+
+- Technical integration patterns between Constitutional Autonomy and AEGIS
+- Potential research collaboration on multi-layer governance
+- Cross-validation opportunities
+
+I'd welcome your thoughts, feedback, or questions either in the GitHub discussion or via email reply. I'm archiving this outreach email in the AEGIS repository under docs/outreach/ to maintain transparency in the project's development process.
+
+**AEGIS Resources:**
+- GitHub: https://github.com/finnoybu/aegis-governance\
+- Constitution: https://aegissystems.app\
+- NIST Position Paper: docs/position-papers/nist/ in the repository
+
+Thank you for your innovative work on Constitutional Autonomy. I look forward to the possibility of exploring how our approaches might work together.
+
+Best regards,
+
+Kenneth Tannenbaum\
+Founder, AEGIS Initiative (Finnoybu IP LLC)\
+IEEE Member #102220161\
+GitHub: https://github.com/finnoybu/aegis-governance
+
+
+> **Privacy Note:** Email addresses have been removed or masked for privacy. The content of the outreach is preserved for transparency in AEGIS project development.
+
+---
+
+## Context
+
+This outreach was initiated following review of Mr. Agbemabiese's paper on Constitutional Autonomy during IEEE Xplore prior art research for AEGIS positioning. The paper proposes model-internal governance through attention mechanism modification, which is complementary to AEGIS's architectural-layer approach.
+
+---
+
+**Constitutional Autonomy Paper:**  
+W. Torgbi Agbemabiese, "Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence," *IEEE Access*, vol. 14, pp. 11385-11402, 2026, doi: 10.1109/ACCESS.2026.3654907.  
+**IEEE Xplore:** https://ieeexplore.ieee.org/document/11354471
+
+**Keywords:** Agentic systems, AI alignment, AI governance, artificial general intelligence, constitutional AI, long-horizon autonomy, runtime validation, sociotechnical validation, theoretical framework
+
+---
+
+> **Transparency Note:** This outreach email is archived publicly in the AEGIS repository to maintain transparency in the project's development and collaboration processes.

--- a/docs/outreach/README.md
+++ b/docs/outreach/README.md
@@ -1,0 +1,26 @@
+# Outreach
+
+Records of outreach to researchers, practitioners, and organizations related to AEGIS™ development.
+
+## Purpose
+
+This directory archives outreach communications to maintain transparency in the AEGIS project's development and collaboration processes. Each file records the content and context of outreach sent on behalf of the AEGIS Initiative.
+
+## Conventions
+
+- Files are named `YYYY-MM-<topic>.md`
+- Email addresses are removed or masked for privacy
+- Header metadata includes: Date, From, To, Status, Response, and Discussion link (where applicable)
+- Status values: `Initial outreach sent`, `Follow-up sent`, `Response received`, `Closed`
+- Response values: `Pending`, `Received`, `No response`
+
+## Log
+
+| Date | Recipient | Topic | Status | Response |
+|------|-----------|-------|--------|----------|
+| 2026-03-13 | William Torgbi Agbemabiese | Constitutional Autonomy + AEGIS multi-layer governance | Initial outreach sent | Pending |
+
+---
+
+**Part of**: AEGIS™ Documentation\
+**Maintained by**: AEGIS™ Initiative


### PR DESCRIPTION
## Summary

- Adds `docs/outreach/` directory for archiving outreach communications
- Initial record: outreach to William Torgbi Agbemabiese (Constitutional Autonomy, IEEE Access 2026) on March 13, 2026
- README establishes naming conventions, status/response vocabulary, and a log table
- Outreach record formatted with blockquotes (not code blocks) for privacy/transparency notes; `Response: Pending` field added to header

## Test plan

- [ ] Verify outreach file renders correctly in GitHub markdown
- [ ] Verify README log table renders correctly
- [ ] Confirm no sensitive email addresses present in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)