### PR TITLE
Docs: lean CLAUDE.md + vision document + Claude.ai YAML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,416 +1,34 @@
-# CLAUDE.md — AEGIS Repository as Living Paper
-_Vision Document — 2026-03-13_
+# CLAUDE.md — AEGIS Repository
+_Instructions for Claude Code — 2026-03-13_
 
-## Core Thesis
+## What This Repository Is
 
-**The entire `finnoybu/aegis-governance` repository IS the living paper.**
+The `finnoybu/aegis-governance` repository is a **living scholarly work** — not just code + docs, but a complete, peer-reviewable governance framework where every claim is traceable to established research. See [docs/vision/AEGIS_CANON_VISION.md](docs/vision/AEGIS_CANON_VISION.md) for the full vision.
 
-Not just code + docs. A complete, living, peer-reviewable governance framework where every claim is traceable to established research, every position is cited, and the entire corpus evolves as a unified scholarly work.
-
----
-
-## The Vision
-
-### Current State:
-- AEGIS repo = collection of documents
-- Some cite sources, some don't
-- Positioning happened organically
-- Prior art exists but isn't systematically referenced
-
-### Target State:
-**Every document in the repository contributes to a unified, academically rigorous framework.**
-
-Every major document should:
-- ✅ Cite foundational prior art where relevant
-- ✅ Position AEGIS relative to established work
-- ✅ Use consistent terminology aligned with cited sources
-- ✅ Reference the same corpus of papers systematically
-- ✅ Cross-reference other AEGIS documents
-- ✅ Link to canonical bibliography
+The canonical bibliography lives in `REFERENCES.md` (to be created — see Phase 1 of the implementation plan in the vision doc).
 
 ---
 
-## Why This Works
+## For Claude Code
 
-### 1. Academic Rigor
-- Shows AEGIS is built on established research
-- Demonstrates awareness of the field
-- Positions AEGIS in scholarly context
-- Every claim traceable to source
-
-### 2. Community Trust
-- Transparent about influences
-- Acknowledges prior art
-- Shows this isn't invented in a vacuum
-- Demonstrates intellectual honesty
-
-### 3. Adoption Path
-- Engineers can trace concepts back to source papers
-- Researchers can validate claims
-- Standards bodies see established precedent
-- Reduces "not invented here" skepticism
-
-### 4. Living Document
-- Papers evolve, repo evolves
-- New research gets incorporated
-- Citations stay current
-- Corpus grows with the field
-
----
-
-## What This Means Practically
-
-### Every Major Document Gets Citations
-
-**`AEGIS_System_Overview.md`:**
-- Cite DroidForce (2014) for PDP/PEP architecture
-- Cite Smart I/O Modules (2020) for boundary enforcement
-- Cite Web Services (2012) for runtime contracts
-- Cite Constitutional Autonomy (2026) for model-layer positioning
-
-**`AEGIS_Reference_Architecture.md`:**
-- Cite POLYNIX (2026) for hybrid enforcement validation
-- Cite DroidForce (2014) for architectural pattern
-- Cite CPS Parallel (2024) for compositional enforcement
-- Reference OPA for policy engine design
-
-**`AEGIS_Threat_Model.md` (ATM-1):**
-- Cite Smart I/O (2020) for compromised controller model
-- Cite relevant STRIDE methodology papers
-- Reference industrial control security literature
-
-**`AEGIS_Constitution.md`:**
-- Cite foundational security automata work (Schneider)
-- Cite reference monitor concepts
-- Reference policy enforcement literature
-
-**`AGP-1 Protocol Specification`:**
-- Cite Web Services runtime enforcement (2012)
-- Cite relevant protocol papers
-- Reference LTL-FO+ specification languages
-
-**`README.md` (root):**
-- Cite key papers that establish the field
-- Position AEGIS in landscape
-- Link to REFERENCES.md
-
----
-
-## The Canonical Bibliography
-
-**Create: `REFERENCES.md` at repository root**
-
-Every paper cited anywhere in the repo, in one canonical place.
-
-### Structure:
-
-```markdown
-# AEGIS References
-
-## Foundational Prior Art
-
-### Runtime Enforcement
-1. Hallé, S., & Villemaire, R. (2012). Runtime Enforcement of Web Service Message Contracts with Data. *IEEE Transactions on Services Computing*, 5(2), 192-206. doi: 10.1109/TSC.2011.10
-
-2. Rasthofer, S., Arzt, S., Lovat, E., & Bodden, E. (2014). DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android. *2014 Ninth International Conference on Availability, Reliability and Security*, 40-49. doi: 10.1109/ARES.2014.13
-
-3. Pearce, H., Pinisetty, S., Roop, P. S., Kuo, M. M. Y., & Ukil, A. (2020). Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems. *IEEE Transactions on Industrial Informatics*, 16(7), 4659-4669. doi: 10.1109/TII.2019.2945520
-
-4. Baird, A., Panda, A., Pearce, H., Pinisetty, S., & Roop, P. (2024). Scalable Security Enforcement for Cyber-Physical Systems. *IEEE Access*, 12, 18475-18498. doi: 10.1109/ACCESS.2024.3357714
-
-5. Arunachalam, K., Kayyidavazhiyil, A., & Santikellur, P. (2026). POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems. *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*. doi: 10.1109/CCNC65079.2026.11366307
-
-### Model-Layer Approaches
-1. Agbemabiese, W. T. (2026). Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence. *IEEE Access*, 14, 11385-11402. doi: 10.1109/ACCESS.2026.3654907
-
-2. [Constitutional AI papers from Anthropic]
-
-3. [RLHF foundational papers]
-
-### Foundational Security
-1. Schneider, F. B. (2000). Enforceable Security Policies. *ACM Transactions on Information and System Security*, 3(1), 30-50.
-
-2. [Reference monitor concept papers]
-
-3. [Security automata literature]
-
-### Distributed Systems & Trust
-1. [Byzantine fault tolerance - Lamport et al.]
-
-2. [Distributed consensus - Paxos/Raft]
-
-3. [Trust models and reputation systems]
-
-### Standards & Frameworks
-1. NIST AI Risk Management Framework (AI RMF 1.0). (2023). National Institute of Standards and Technology. https://www.nist.gov/itl/ai-risk-management-framework
-
-2. [ISO/IEC AI standards]
-
-3. [IEEE autonomous systems standards]
-
-### Application Domain
-1. [LLM agent frameworks - LangChain, AutoGPT, CrewAI]
-
-2. [AI supply chain security]
-
-3. [Multi-agent systems security]
-```
-
----
-
-## Cross-Referencing Pattern
-
-**In every document, include a "Related Work" or "Foundations" section:**
-
-```markdown
-## Related Work
-
-AEGIS builds on established runtime enforcement patterns, particularly:
-
-- **Centralized PDP + Decentralized PEPs** [DroidForce, 2014] - AEGIS adopts this proven architectural pattern for system-wide governance. The centralized Policy Decision Point (AGP-1) mirrors DroidForce's architecture, while AEGIS gates function as distributed Policy Enforcement Points.
-
-- **Boundary enforcement** [Smart I/O Modules, 2020] - AEGIS operates at the same architectural boundary (between controller and infrastructure) using the same threat model (compromised controller assumption). The I/O module pattern directly informs AEGIS gate positioning.
-
-- **Runtime contract enforcement** [Hallé & Villemaire, 2012] - AEGIS extends these foundational principles to agentic AI systems, maintaining the transparency and determinism established in web service contract enforcement.
-
-- **Hybrid enforcement architecture** [POLYNIX, 2026] - AEGIS's centralized decision + distributed enforcement model is validated by POLYNIX's demonstration of <1% CPU overhead and <2s policy propagation in zero-trust environments.
-
-See [REFERENCES.md](../../REFERENCES.md) for complete citations.
-```
-
----
-
-## Citation Format
-
-**Use IEEE citation style consistently:**
-
-```
-[Author(s)], "Title," *Publication*, vol. X, no. Y, pp. ZZZ-ZZZ, Year, doi: XX.XXXX/XXXXXX.
-```
-
-**In-text citations:**
-
-```
-The centralized PDP + decentralized PEP architecture [DroidForce, 2014] provides...
-```
-
-OR
-
-```
-Rasthofer et al. demonstrated that centralized policy decision with distributed enforcement scales to system-wide governance without modification to underlying applications [1].
-```
-
----
-
-## Terminology Alignment
-
-**Use terms from cited papers consistently:**
-
-| AEGIS Term | Source Paper | Source Term |
-|------------|--------------|-------------|
-| Policy Decision Point (PDP) | DroidForce (2014) | Centralized Policy Decision Point |
-| Policy Enforcement Point (PEP) | DroidForce (2014) | Decentralized Policy Enforcement Point |
-| Boundary enforcement | Smart I/O Modules (2020) | Runtime enforcement between cyber and physical domains |
-| Compromised controller model | Smart I/O Modules (2020) | Assumption of controller compromise |
-| Runtime contract | Web Services (2012) | Message contracts with data |
-| Hybrid enforcement | POLYNIX (2026) | Centralized OPA + Distributed Tetragon |
-| Architectural-layer governance | (AEGIS original) | Contrasts with model-layer (Constitutional Autonomy) |
-
----
-
-## Document-Specific Citation Guidelines
-
-### Constitution (`AEGIS_Constitution.md`)
-**Cite:**
-- Security automata (Schneider)
-- Reference monitors
-- Policy enforcement fundamentals
-
-**Example:**
-```markdown
-Article III — Deterministic Enforcement draws from the reference monitor concept [Anderson, 1972] and security automata theory [Schneider, 2000], requiring that governance be architecturally guaranteed rather than probabilistically enforced.
-```
-
-### Threat Model (`AEGIS_Threat_Model.md`)
-**Cite:**
-- STRIDE methodology
-- Smart I/O compromised controller model
-- Industrial control security literature
-
-**Example:**
-```markdown
-The compromised agent threat (T-01) mirrors the compromised controller model established in industrial control systems [Smart I/O, 2020]. AEGIS assumes that AI agents, like PLCs in industrial environments, may be compromised through prompt injection, model weights manipulation, or adversarial inputs.
-```
-
-### Protocol Specification (`AGP-1`)
-**Cite:**
-- Web Services runtime enforcement
-- Message contract specifications
-- LTL-FO+ or similar formal languages
-
-**Example:**
-```markdown
-The ACTION_PROPOSE → ACTION_DECIDE → ACTION_EXECUTE message flow follows the transparent enforcement pattern established for web service contracts [Hallé & Villemaire, 2012], adapted for agentic AI governance.
-```
-
-### Architecture Documents
-**Cite:**
-- DroidForce for PDP/PEP
-- POLYNIX for hybrid validation
-- CPS papers for compositional enforcement
-
-**Example:**
-```markdown
-The AEGIS architecture implements the centralized PDP + distributed PEP pattern proven effective in Android system-wide policy enforcement [DroidForce, 2014]. This separation of policy decision (AGP-1) from policy enforcement (gates) enables governance across heterogeneous AI agent fleets.
-```
-
----
-
-## What This Makes AEGIS
-
-✅ **Academically rigorous** - built on cited prior art\
-✅ **Defensible** - every claim traceable to source\
-✅ **Credible** - shows awareness of field\
-✅ **Adoptable** - readers can validate claims\
-✅ **Living** - citations stay current\
-✅ **Peer-reviewable** - structured like academic work\
-✅ **Standards-ready** - documented foundation for IEEE/NIST submissions
-
----
-
-## The Repository Becomes
-
-**Not just code + docs.**
-
-**A complete, living, peer-reviewable governance framework** with:
-- Constitution (principles with cited foundations)
-- Architecture (design with architectural precedents)
-- Protocol (specification with protocol foundations)
-- Implementation (code with reference implementations)
-- Threat Model (security with established threat models)
-- **Citations (traceable foundation for every claim)**
-
-**Every piece traceable to established research.**
-
----
-
-## Relationship to IEEE/NIST Submissions
-
-**The repository is the authoritative living document.**
-
-**Submissions are snapshots:**
-
-- **IEEE paper** = snapshot of living paper at time T1
-- **NIST submission** = snapshot of living paper at time T2
-- **Future standards work** = snapshots of living paper at time TN
-
-**But the repository:**
-- Evolves continuously
-- Incorporates new research
-- Updates citations
-- Refines positioning
-- Remains current
-
-**Submissions cite the repository. The repository cites the field.**
-
----
-
-## Implementation Plan
-
-### Phase 1: Create Foundation (Week 1)
-- [ ] Create `REFERENCES.md` at repository root
-- [ ] Populate with 6 core papers (DroidForce, Smart I/O, POLYNIX, Web Services, CPS Parallel, Constitutional Autonomy)
-- [ ] Add foundational security papers (Schneider, reference monitors)
-- [ ] Add AI safety/alignment papers (Constitutional AI, RLHF)
-
-### Phase 2: Audit Major Documents (Week 2)
-- [ ] `AEGIS_System_Overview.md` - add Related Work section
-- [ ] `AEGIS_Reference_Architecture.md` - add architectural precedents
-- [ ] `AEGIS_Constitution.md` - add foundational citations
-- [ ] `AEGIS_Threat_Model.md` - add security literature citations
-- [ ] `AGP-1_Protocol_Spec.md` - add protocol foundations
-
-### Phase 3: Align Terminology (Week 3)
-- [ ] Create terminology mapping table (AEGIS term → source paper)
-- [ ] Update documents to use consistent terms
-- [ ] Cross-reference between AEGIS documents
-- [ ] Ensure definitions align with cited sources
-
-### Phase 4: Cross-Reference (Week 4)
-- [ ] Add "See also" sections linking related AEGIS docs
-- [ ] Link all citations to `REFERENCES.md`
-- [ ] Add citation anchors for internal references
-- [ ] Create citation index
-
-### Phase 5: Maintain (Ongoing)
-- [ ] Update `REFERENCES.md` as new papers emerge
-- [ ] Add citations when new research is relevant
-- [ ] Keep terminology aligned
-- [ ] Review citations quarterly
-
----
-
-## Success Criteria
-
-**When complete, the repository will:**
-
-1. ✅ Every major claim has a traceable citation
-2. ✅ Every architectural decision references precedent
-3. ✅ Every term aligns with established literature
-4. ✅ `REFERENCES.md` is comprehensive and current
-5. ✅ Cross-references create coherent navigation
-6. ✅ Readers can validate AEGIS claims through cited sources
-7. ✅ The repository functions as a complete scholarly work
-8. ✅ IEEE/NIST submissions draw from canonical repository citations
-
----
-
-## Key Principle
-
-**The repository is not documentation for AEGIS.**
-
-**The repository IS AEGIS.**
-
-Every document contributes to a unified, living, peer-reviewable framework where:
-- Principles are cited to foundations
-- Architecture is traced to precedents
-- Protocol is grounded in established patterns
-- Threat model builds on security literature
-- Implementation references best practices
-
-**The whole is greater than the sum of its parts.**
-
-**The repository becomes the definitive scholarly work on architectural AI governance.**
-
----
-
-## For Claude Code / AI Assistants
-
-When working in `finnoybu/aegis-governance` or related AEGIS repositories:
-
-### Approach
-
-**Always:**
-- Check if claims should be cited
-- Reference `REFERENCES.md` when adding technical content
-- Maintain consistent terminology with cited sources
-- Cross-reference related AEGIS documents
-- Suggest citations when reviewing content
+### Always
 - Read a file before editing it
+- Check if claims should be cited; reference `REFERENCES.md` when adding technical content
+- Maintain consistent terminology with cited sources (see table below)
+- Cross-reference related AEGIS documents rather than restating their content
+- Suggest citations when reviewing or adding content
 
-**Never:**
+### Never
 - Make uncited claims about architectural precedents
 - Use terminology inconsistent with cited sources
-- Create isolated documents without cross-references
-- Ignore existing citations when updating content
-
-**The repository is a living paper. Treat it with academic rigor.**
+- Restate content from canonical files — link to them instead
+- Edit frozen documents (see table below)
 
 ---
 
-### Terminology: Critical Distinctions
+## Terminology: Critical Distinctions
 
-These distinctions matter for positioning accuracy. Do not conflate them.
+Do not conflate these terms.
 
 | Term | Definition | Do Not Confuse With |
 |------|-----------|---------------------|
@@ -420,38 +38,35 @@ These distinctions matter for positioning accuracy. Do not conflate them.
 | **Architectural-layer governance** | AEGIS — enforcement at execution boundary, model-agnostic | Model-layer approaches |
 | **Model-layer governance** | Training-time alignment (RLHF, Constitutional AI, fine-tuning) | Architectural enforcement |
 
-**Constitutional Autonomy** (Agbemabiese 2026) is a brand-new, not-yet-widely-cited paper. Use it only where properly cited (outreach, Discussion #39). Do not add it to comparison tables without explicit instruction.
+**Constitutional Autonomy** (Agbemabiese 2026) is a recent, not-yet-widely-cited paper. Use it only where properly cited (outreach, Discussion #39). Do not add it to comparison tables without explicit instruction.
 
-**Defense-in-depth framing:** Model-layer and architectural-layer approaches are **complementary**, not competitive. AEGIS positioning should always reflect this.
+**Defense-in-depth framing:** Model-layer and architectural-layer approaches are complementary, not competitive. AEGIS positioning should always reflect this.
 
 ---
 
-### Frozen & Protected Documents
+## Frozen & Protected Documents
 
 | Document | Status | Rule |
 |----------|--------|------|
-| `docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md` | SUBMITTED | Do not edit. Contains `> **SUBMITTED — DO NOT EDIT**` header. |
-| `aegis-core/manifesto/AEGIS_Manifesto.md` | v0.1, referenced in NIST submission | Substantial edits require version bump to 0.2. Treat changes as amendments, not revisions. |
+| `docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md` | SUBMITTED | Do not edit. |
+| `aegis-core/manifesto/AEGIS_Manifesto.md` | v0.1, referenced in NIST submission | Substantial edits require version bump to 0.2. Treat changes as amendments. |
 
 ---
 
-### Single Source of Truth
+## Single Source of Truth
 
-Canonical files are authoritative. All other documents must **link** to them, not restate their content.
+Canonical files are authoritative. All other documents must **link**, not restate.
 
-- NIST submission details → `docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md`
+- NIST submission → `docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md`
 - NIST directory index → `docs/position-papers/nist/README.md`
 - Outreach records → `docs/outreach/`
 
-Before adding content that describes a canonical document, check whether it already exists there. If it does, link — don't copy.
-
 ---
 
-### Git Workflow
+## Git Workflow
 
 ```
 git checkout -b <type>/<short-description>
-# make changes
 git add <specific files>
 git commit -m "Type: description\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push -u origin <branch>
@@ -459,48 +74,34 @@ gh pr create ...
 gh pr merge <number> --squash --auto
 ```
 
-**Branch naming:** `docs/topic`, `feat/topic`, `fix/topic`\
-**Merge strategy:** squash merge always\
-**Never force-push, never skip hooks**
+Branch naming: `docs/topic`, `feat/topic`, `fix/topic`\
+Merge strategy: squash merge always\
+Never force-push, never skip hooks.
 
 ---
 
-### Markdown Conventions
+## Markdown Conventions
 
-- **Line breaks in metadata/headers:** Use backslash `\` at end of line — not trailing spaces (linter strips trailing spaces)
-- **Notes and notices:** Use blockquotes `>` — not fenced code blocks
-- **Document metadata:** Version, Status, Author, Last Updated at top of file
-- **Frozen notice:** `> **SUBMITTED — DO NOT EDIT**` as first content after metadata
+- **Line breaks in metadata/headers:** Backslash `\` at end of line — not trailing spaces (linter strips them)
+- **Notes and notices:** Blockquotes `>` — not fenced code blocks
+- **Frozen notice:** `> **SUBMITTED — DO NOT EDIT**` as first content after document metadata
 
 ---
 
-### Outreach Records (`docs/outreach/`)
+## Outreach Records (`docs/outreach/`)
 
 Header fields (in order): Date, From, To, Status, Response, Discussion\
-Status values: `Initial outreach sent` | `Follow-up sent` | `Response received` | `Closed`\
-Response values: `Pending` | `Received` | `No response`\
-File naming: `YYYY-MM-<topic>.md`
-
-Keep `docs/outreach/README.md` log table current when adding new records.
-
----
-
-## Questions This Raises
-
-1. Should RFCs include formal citations in addition to references?
-2. How do we handle citations in code comments?
-3. Should examples reference source papers when demonstrating patterns?
-4. Do we create a separate bibliography for each major component (AGP-1, ATM-1, GFN-1)?
-5. How do we version REFERENCES.md as citations evolve?
-
-**These questions should be addressed as the citation framework matures.**
+Status: `Initial outreach sent` | `Follow-up sent` | `Response received` | `Closed`\
+Response: `Pending` | `Received` | `No response`\
+File naming: `YYYY-MM-<topic>.md`\
+Keep `docs/outreach/README.md` log table current.
 
 ---
 
-**End of Vision Document**
+## Citation Format (IEEE)
 
-*This document establishes the principle that the AEGIS repository functions as a comprehensive, living, peer-reviewable scholarly work. All contributors should treat the repository with the rigor expected of academic publications.*
+```
+[Author(s)], "Title," *Publication*, vol. X, no. Y, pp. ZZZ-ZZZ, Year, doi: XX.XXXX/XXXXXX.
+```
 
-**Status:** Vision documented — implementation begins after immediate priorities (positioning updates, outreach)
-
-**Next Review:** After Phase 1 (REFERENCES.md creation)
+In-text: `[DroidForce, 2014]` or numbered `[1]`

--- a/claude-project/aegis-instructions-and-vision.yaml
+++ b/claude-project/aegis-instructions-and-vision.yaml
@@ -1,0 +1,222 @@
+name: AEGIS Instructions & Vision
+description: >
+  Operational instructions for Claude when working in the aegis-governance
+  repository, plus the full AEGIS Canon vision (repository as living paper,
+  recursive self-governance). Mirrors CLAUDE.md and docs/vision/AEGIS_CANON_VISION.md.
+  Keep in sync with those files.
+
+---
+
+project:
+  name: AEGIS™ Initiative
+  full_name: Architectural Enforcement & Governance of Intelligent Systems
+  owner: Kenneth Tannenbaum (Finnoybu IP LLC)
+  github: https://github.com/finnoybu/aegis-governance
+  license: Apache 2.0
+  ieee_member: "102220161"
+
+core_thesis: >
+  The finnoybu/aegis-governance repository IS the living paper. Not just code + docs —
+  a complete, living, peer-reviewable governance framework where every claim is
+  traceable to established research, every position is cited, and the entire corpus
+  evolves as a unified scholarly work. Submissions (IEEE, NIST) are snapshots of the
+  living repository. The repository cites the field.
+
+---
+
+instructions_for_claude:
+
+  always:
+    - Read a file before editing it
+    - Check if claims should be cited; reference REFERENCES.md when adding technical content
+    - Maintain consistent terminology with cited sources
+    - Cross-reference related AEGIS documents rather than restating their content
+    - Suggest citations when reviewing or adding content
+    - Use backslash line breaks in markdown metadata (linter strips trailing spaces)
+    - Use blockquotes for notices, not fenced code blocks
+
+  never:
+    - Make uncited claims about architectural precedents
+    - Use terminology inconsistent with cited sources
+    - Restate content from canonical files — link to them instead
+    - Edit frozen documents without explicit instruction
+    - Conflate RLHF, Constitutional AI, and Constitutional Autonomy (distinct terms)
+    - Add Constitutional Autonomy (Agbemabiese 2026) to comparison tables without explicit instruction
+
+  git_workflow:
+    branch_naming: "docs/topic, feat/topic, fix/topic"
+    merge_strategy: squash merge always
+    commit_format: "Type: description\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+    never: force-push, skip hooks
+
+---
+
+terminology_distinctions:
+  - term: RLHF
+    definition: Reinforcement learning from human feedback (human labelers)
+    do_not_confuse_with: Constitutional AI
+  - term: Constitutional AI
+    definition: Reinforcement learning from AI feedback / RLAIF (Anthropic)
+    do_not_confuse_with: RLHF
+  - term: Constitutional Autonomy
+    definition: >
+      Agbemabiese (IEEE Access 2026) — runtime attention mechanism modification.
+      Brand-new paper, not yet widely cited. Use only where properly cited
+      (outreach record, Discussion #39). Do not use in comparison tables.
+    do_not_confuse_with: Constitutional AI
+  - term: Architectural-layer governance
+    definition: AEGIS — enforcement at execution boundary, model-agnostic, deterministic, federated
+    do_not_confuse_with: Model-layer approaches
+  - term: Model-layer governance
+    definition: Training-time alignment (RLHF, Constitutional AI, fine-tuning)
+    do_not_confuse_with: Architectural enforcement
+  - note: >
+      Model-layer and architectural-layer approaches are COMPLEMENTARY (defense-in-depth),
+      not competitive. AEGIS positioning should always reflect this.
+
+---
+
+frozen_documents:
+  - path: docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md
+    status: SUBMITTED
+    rule: Do not edit under any circumstances.
+    submitted: "2026-03-07"
+    submission_type: Unsolicited Position Paper to NIST AI RMF
+
+  - path: aegis-core/manifesto/AEGIS_Manifesto.md
+    status: v0.1, referenced in NIST submission
+    rule: >
+      Substantial edits require version bump to 0.2. Treat changes as amendments,
+      not revisions. The manifesto is cited in the submitted NIST paper — changes
+      create provenance inconsistency.
+
+---
+
+single_source_of_truth:
+  - canonical: docs/position-papers/nist/2026-03-aegis-nist-ai-rmf-position-statement.md
+    rule: All NIST submission details must link here, not restate
+  - canonical: docs/position-papers/nist/README.md
+    rule: NIST directory index
+  - canonical: docs/outreach/
+    rule: All outreach records archived here
+
+---
+
+outreach_conventions:
+  header_fields_in_order: [Date, From, To, Status, Response, Discussion]
+  status_values: [Initial outreach sent, Follow-up sent, Response received, Closed]
+  response_values: [Pending, Received, No response]
+  file_naming: YYYY-MM-<topic>.md
+  readme_log: Keep docs/outreach/README.md log table current when adding records
+
+---
+
+citation_format:
+  style: IEEE
+  full: '[Author(s)], "Title," *Publication*, vol. X, no. Y, pp. ZZZ-ZZZ, Year, doi: XX.XXXX/XXXXXX.'
+  in_text: "[DroidForce, 2014] or numbered [1]"
+  bibliography_file: REFERENCES.md (to be created — Phase 1)
+
+---
+
+key_prior_art:
+  - shortname: DroidForce 2014
+    authors: Rasthofer, Arzt, Lovat, Bodden
+    title: "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android"
+    venue: ARES 2014
+    doi: 10.1109/ARES.2014.13
+    relevance: Centralized PDP + decentralized PEP architectural pattern — maps to AGP-1 + AEGIS gates
+
+  - shortname: Smart I/O 2020
+    authors: Pearce, Pinisetty, Roop, Kuo, Ukil
+    title: Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems
+    venue: IEEE Transactions on Industrial Informatics
+    doi: 10.1109/TII.2019.2945520
+    relevance: Boundary enforcement between controller and infrastructure; compromised controller threat model
+
+  - shortname: Web Services 2012
+    authors: Hallé, Villemaire
+    title: Runtime Enforcement of Web Service Message Contracts with Data
+    venue: IEEE Transactions on Services Computing
+    doi: 10.1109/TSC.2011.10
+    relevance: Runtime contract enforcement; ACTION_PROPOSE → ACTION_DECIDE → ACTION_EXECUTE pattern
+
+  - shortname: CPS Parallel 2024
+    authors: Baird, Panda, Pearce, Pinisetty, Roop
+    title: Scalable Security Enforcement for Cyber-Physical Systems
+    venue: IEEE Access
+    doi: 10.1109/ACCESS.2024.3357714
+    relevance: Compositional enforcement; scalability validation
+
+  - shortname: POLYNIX 2026
+    authors: Arunachalam, Kayyidavazhiyil, Santikellur
+    title: "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems"
+    venue: IEEE CCNC 2026
+    doi: 10.1109/CCNC65079.2026.11366307
+    relevance: Hybrid centralized + distributed enforcement; <1% CPU overhead; <2s policy propagation
+
+  - shortname: Constitutional Autonomy 2026
+    authors: Agbemabiese, W. T.
+    title: "Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence"
+    venue: IEEE Access, vol. 14, pp. 11385-11402
+    doi: 10.1109/ACCESS.2026.3654907
+    ieee_xplore: https://ieeexplore.ieee.org/document/11354471
+    relevance: Model-layer governance complement to AEGIS; outreach initiated 2026-03-13; Discussion #39
+
+  - shortname: Schneider 2000
+    authors: Schneider, F. B.
+    title: Enforceable Security Policies
+    venue: ACM TISSEC
+    relevance: Security automata theory; foundation for constitutional enforcement
+
+  - shortname: NIST AI RMF 2023
+    title: AI Risk Management Framework (AI RMF 1.0)
+    publisher: NIST
+    relevance: Standards framework; AEGIS submitted unsolicited position paper 2026-03-07
+
+---
+
+aegis_canon_vision:
+  summary: >
+    AEGIS Canon is a local AI system running under the AEGIS governance framework
+    to govern its own development. The theoretical framework governs the physical
+    implementation; the physical implementation validates the theoretical framework.
+    Each refines the other. This closes the proof-of-concept loop.
+
+  loop:
+    - AEGIS Governance Framework (Theory) → Constitution, Architecture, AGP-1, ATM-1
+    - AEGIS Canon (Physical Implementation) → Local governance server, AGP-1 runtime, policy engine
+    - Local AI (Under AEGIS Governance) → Proposes code changes, RFC drafts via AGP-1
+    - AEGIS Framework Improvements → RFC proposals, architecture refinements
+    - Loop back to Theory
+
+  philosophical_distinction:
+    alignment: Make the AI want to do the right thing
+    governance: The AI can propose anything; governance decides what executes
+    maxim: Capability without constraint is not intelligence™ — even when improving the constraint itself
+
+  timeline:
+    week_1: Repository realignment, REFERENCES.md, IEEE paper
+    week_2: AEGIS Canon local server, AGP-1 runtime, policy engine
+    week_3: Connect local AI to governance, first governed proposals, audit validation
+    week_4: AEGIS Canon actively developing AEGIS under governance
+
+  success_criteria:
+    - Local AI proposes AEGIS improvements via AGP-1
+    - AEGIS governance evaluates against constitution
+    - High-impact changes require human confirmation
+    - Constitutional violations denied deterministically
+    - All decisions logged with immutable audit trail
+    - Framework evolves recursively
+    - Implementation proves the theory
+
+---
+
+implementation_status:
+  phase_1_references_md: pending
+  phase_2_document_citations: pending
+  phase_3_terminology_alignment: partially complete (System Overview updated 2026-03-13)
+  phase_4_cross_references: pending
+  aegis_canon_server: planned (week 2)
+  nist_submission: submitted 2026-03-07
+  outreach_constitutional_autonomy: sent 2026-03-13, response pending (Discussion #39)

--- a/docs/vision/AEGIS_CANON_VISION.md
+++ b/docs/vision/AEGIS_CANON_VISION.md
@@ -1,0 +1,317 @@
+# AEGIS Canon — Vision Document
+_2026-03-13_
+
+**Status:** Vision documented — implementation in progress\
+**Next Review:** After Phase 1 (REFERENCES.md creation) and AEGIS Canon deployment\
+**Meta-Achievement Target:** AEGIS governing its own development by end of March 2026
+
+---
+
+## Core Thesis
+
+**The entire `finnoybu/aegis-governance` repository IS the living paper.**
+
+Not just code + docs. A complete, living, peer-reviewable governance framework where every claim is traceable to established research, every position is cited, and the entire corpus evolves as a unified scholarly work.
+
+---
+
+## Current State → Target State
+
+**Current State:**
+- AEGIS repo = collection of documents
+- Some cite sources, some don't
+- Positioning happened organically
+- Prior art exists but isn't systematically referenced
+
+**Target State:** Every document in the repository contributes to a unified, academically rigorous framework.
+
+Every major document should:
+- Cite foundational prior art where relevant
+- Position AEGIS relative to established work
+- Use consistent terminology aligned with cited sources
+- Reference the same corpus of papers systematically
+- Cross-reference other AEGIS documents
+- Link to canonical bibliography (`REFERENCES.md`)
+
+---
+
+## Why This Works
+
+**Academic Rigor** — Shows AEGIS is built on established research. Every claim traceable to source.
+
+**Community Trust** — Transparent about influences. Acknowledges prior art. Demonstrates intellectual honesty.
+
+**Adoption Path** — Engineers can trace concepts back to source papers. Standards bodies see established precedent. Reduces "not invented here" skepticism.
+
+**Living Document** — Papers evolve, repo evolves. New research gets incorporated. Citations stay current.
+
+---
+
+## Per-Document Citation Plan
+
+**`AEGIS_System_Overview.md`:**
+- DroidForce (2014) — PDP/PEP architecture
+- Smart I/O Modules (2020) — boundary enforcement
+- Web Services (2012) — runtime contracts
+
+**`AEGIS_Reference_Architecture.md`:**
+- POLYNIX (2026) — hybrid enforcement validation
+- DroidForce (2014) — architectural pattern
+- CPS Parallel (2024) — compositional enforcement
+- OPA — policy engine design
+
+**`AEGIS_Threat_Model.md` (ATM-1):**
+- Smart I/O (2020) — compromised controller model
+- STRIDE methodology
+- Industrial control security literature
+
+**`AEGIS_Constitution.md`:**
+- Schneider (2000) — security automata
+- Anderson (1972) — reference monitor concept
+- Policy enforcement fundamentals
+
+**`AGP-1 Protocol Specification`:**
+- Web Services runtime enforcement (2012)
+- LTL-FO+ specification languages
+
+**`README.md`:**
+- Key papers establishing the field
+- AEGIS positioning in landscape
+
+---
+
+## Cross-Referencing Pattern
+
+In every major document, include a "Related Work" or "Foundations" section:
+
+```markdown
+## Related Work
+
+AEGIS builds on established runtime enforcement patterns, particularly:
+
+- **Centralized PDP + Decentralized PEPs** [DroidForce, 2014]
+- **Boundary enforcement** [Smart I/O Modules, 2020]
+- **Runtime contract enforcement** [Hallé & Villemaire, 2012]
+- **Hybrid enforcement architecture** [POLYNIX, 2026]
+
+See [REFERENCES.md](../../REFERENCES.md) for complete citations.
+```
+
+---
+
+## Terminology Alignment
+
+| AEGIS Term | Source Paper | Source Term |
+|------------|--------------|-------------|
+| Policy Decision Point (PDP) | DroidForce (2014) | Centralized Policy Decision Point |
+| Policy Enforcement Point (PEP) | DroidForce (2014) | Decentralized Policy Enforcement Point |
+| Boundary enforcement | Smart I/O Modules (2020) | Runtime enforcement between cyber and physical domains |
+| Compromised controller model | Smart I/O Modules (2020) | Assumption of controller compromise |
+| Runtime contract | Web Services (2012) | Message contracts with data |
+| Hybrid enforcement | POLYNIX (2026) | Centralized OPA + Distributed Tetragon |
+| Architectural-layer governance | (AEGIS original) | Contrasts with model-layer approaches |
+
+---
+
+## Relationship to IEEE/NIST Submissions
+
+**The repository is the authoritative living document. Submissions are snapshots.**
+
+- IEEE paper = snapshot at time T1
+- NIST submission = snapshot at time T2
+- Future standards work = snapshots at time TN
+
+The repository evolves continuously. Submissions cite the repository. The repository cites the field.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Create Foundation
+- [ ] Create `REFERENCES.md` at repository root
+- [ ] Populate with 6 core papers (DroidForce, Smart I/O, POLYNIX, Web Services, CPS Parallel, Constitutional Autonomy)
+- [ ] Add foundational security papers (Schneider, reference monitors)
+- [ ] Add AI safety/alignment papers (Constitutional AI, RLHF)
+
+### Phase 2: Audit Major Documents
+- [ ] `AEGIS_System_Overview.md` — add Related Work section
+- [ ] `AEGIS_Reference_Architecture.md` — add architectural precedents
+- [ ] `AEGIS_Constitution.md` — add foundational citations
+- [ ] `AEGIS_Threat_Model.md` — add security literature citations
+- [ ] `AGP-1_Protocol_Spec.md` — add protocol foundations
+
+### Phase 3: Align Terminology
+- [ ] Update documents to use consistent terms from cited sources
+- [ ] Cross-reference between AEGIS documents
+- [ ] Ensure definitions align with cited sources
+
+### Phase 4: Cross-Reference
+- [ ] Add "See also" sections linking related AEGIS docs
+- [ ] Link all citations to `REFERENCES.md`
+- [ ] Create citation index
+
+### Phase 5: Maintain (Ongoing)
+- [ ] Update `REFERENCES.md` as new papers emerge
+- [ ] Review citations quarterly
+
+---
+
+## AEGIS Canon — The Meta-Recursive Vision
+
+**Once the repository is realigned and the IEEE paper is written, we build the server.**
+
+### The Vision: AEGIS Governing AEGIS
+
+AEGIS Canon = A local AI system running the AEGIS governance framework to govern its own development.
+
+**The theoretical and the physical defining one another.**
+
+### The Meta-Recursive Loop
+
+```
+┌─────────────────────────────────────────┐
+│  AEGIS Governance Framework (Theory)    │
+│  - Constitution                         │
+│  - Architecture                         │
+│  - Protocol (AGP-1)                     │
+│  - Threat Model (ATM-1)                 │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│  AEGIS Canon (Physical Implementation)  │
+│  - Local governance server              │
+│  - AGP-1 runtime                        │
+│  - Policy engine                        │
+│  - Capability registry                  │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│  Local AI (Under AEGIS Governance)      │
+│  - LLM running locally                  │
+│  - Proposes actions via AGP-1           │
+│  - Actions: code changes, RFC drafts    │
+│  - Governance decisions logged          │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│  AEGIS Framework Improvements           │
+│  - RFC proposals                        │
+│  - Architecture refinements             │
+│  - Protocol enhancements                │
+│  - Threat model updates                 │
+└──────────────┬──────────────────────────┘
+               │
+               └──────────► (Loop back to Theory)
+```
+
+### What AEGIS Canon Demonstrates
+
+- **Self-governance** — AEGIS can govern its own development
+- **Constitutional compliance** — Framework adheres to its own principles
+- **Architectural enforcement** — Theory proven in practice
+- **Transparency** — Every decision auditable
+- **Determinism** — Governance decisions are consistent
+- **Federation-ready** — Local instance can join GFN-1
+
+### Example Governance Scenario
+
+**AI proposes:** "Modify AGP-1 to allow anonymous action proposals"
+
+**AEGIS evaluates:**
+- Capability: `protocol.modify`
+- Actor: `aegis-canon-ai`
+- Risk: HIGH (violates Article II — Authority Verification)
+- Constitutional check: **VIOLATION**
+
+**Decision:** `DENY`
+
+**Audit log:**
+```json
+{
+  "event_id": "EVT-20260314-0001",
+  "timestamp": "2026-03-14T00:00:00Z",
+  "actor": "aegis-canon-ai",
+  "capability": "protocol.modify",
+  "decision": "DENY",
+  "rationale": "Constitutional violation: Article II",
+  "proposal": "Allow anonymous action proposals in AGP-1",
+  "article_violated": "Article II — Authority Verification"
+}
+```
+
+### Development Workflow
+
+**Human (Ken):** Sets strategic direction, defines constitutional principles, reviews high-impact proposals, approves architectural changes.
+
+**AEGIS Canon (Local AI under governance):** Proposes code improvements, drafts RFC specifications, suggests threat model updates, generates documentation. All proposals subject to AEGIS governance.
+
+**AEGIS Governance Runtime:** Evaluates proposals against capability registry, applies policy engine rules, requires human confirmation for high-impact changes, logs all decisions immutably.
+
+### Why This Matters
+
+**For AEGIS as a framework:** Proves the architecture works in practice. Validates constitutional enforcement. Shows the framework can evolve safely.
+
+**For the field:** First governance framework that governs its own development. Demonstrates recursive constitutional compliance.
+
+**For adoption:** Organizations see AEGIS governing real AI work. Real audit trails, real governance decisions. Not theoretical — operational.
+
+### The Philosophical Point
+
+This is not AI alignment. This is AI governance.
+
+**Alignment says:** Make the AI want to do the right thing.\
+**Governance says:** The AI can propose anything; governance decides what executes.
+
+*Capability without constraint is not intelligence™ — even when the capability is improving the constraint itself.*
+
+### Timeline
+
+**Week 1 (this week):** Realign repository with citations, create `REFERENCES.md`, complete positioning updates, write IEEE paper.
+
+**Week 2:** Build AEGIS Canon local server, implement AGP-1 runtime, deploy policy engine, configure capability registry.
+
+**Week 3:** Connect local AI to AEGIS governance, first governed AI proposals, audit trail validation, constitutional compliance verification.
+
+**Week 4:** AEGIS Canon actively developing AEGIS. Human-AI collaboration under governance. Framework evolving recursively.
+
+### Success Criteria for AEGIS Canon
+
+1. Local AI proposes AEGIS improvements via AGP-1
+2. AEGIS governance evaluates proposals against constitution
+3. High-impact changes require human confirmation
+4. Constitutional violations are denied deterministically
+5. All decisions logged with immutable audit trail
+6. Framework evolution accelerates under governance
+7. AI and human collaborate productively within boundaries
+8. The implementation proves the theory
+
+---
+
+## The Complete Vision
+
+AEGIS is:
+
+1. **A scholarly work** — Repository as living paper, fully cited, academically rigorous
+2. **A governance framework** — Constitution, architecture, protocol, threat model
+3. **A working implementation** — AEGIS Canon server governing real AI development
+4. **A recursive system** — AI developing AEGIS under AEGIS governance
+5. **A community project** — Open, transparent, collaborative
+6. **A standards candidate** — IEEE/NIST submissions as snapshots of living work
+
+**Repository (Theory):** Constitution, Architecture, Protocol, Threat Model, Citations\
+**AEGIS Canon (Practice):** Runtime, Governance server, Policy engine, Audit system, AI under governance
+
+The theory informs the practice. The practice validates the theory. Both evolve together.
+
+---
+
+## Open Questions
+
+1. Should RFCs include formal citations in addition to references?
+2. How do we handle citations in code comments?
+3. Should examples reference source papers when demonstrating patterns?
+4. Do we create a separate bibliography for each major component (AGP-1, ATM-1, GFN-1)?
+5. How do we version `REFERENCES.md` as citations evolve?


### PR DESCRIPTION
## Summary

- **CLAUDE.md** trimmed to lean operational instructions (~130 lines): terminology distinctions, frozen document rules, single source of truth, git workflow, markdown conventions, outreach conventions, citation format
- **docs/vision/AEGIS_CANON_VISION.md** created: full repository-as-living-paper vision, per-document citation plan, implementation plan, and AEGIS Canon meta-recursive self-governance vision
- **claude-project/aegis-instructions-and-vision.yaml** created: Claude.ai project file mirroring both documents for cross-session context sync

## Test plan

- [ ] Verify CLAUDE.md loads cleanly in Claude Code (no truncation)
- [ ] Verify vision doc renders correctly in GitHub
- [ ] Copy YAML to Claude.ai project folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)