### PR TITLE
Docs: update NIST citation [13] with DOI and add EU AI Act [15]

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -67,10 +67,13 @@ See [CLAUDE.md](CLAUDE.md) for citation format conventions.
 
 ## Standards & Frameworks
 
-[13] National Institute of Standards and Technology, *Artificial Intelligence Risk Management Framework (AI RMF 1.0)*, NIST AI 100-1, Jan. 2023. [Online]. Available: https://www.nist.gov/itl/ai-risk-management-framework\
+[13] National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Washington, DC, Jan. 2023, doi: 10.6028/NIST.AI.100-1. [Online]. Available: https://doi.org/10.6028/NIST.AI.100-1\
 **Relevance to AEGIS:** Primary standards framework context for AEGIS. AEGIS submitted an unsolicited position paper proposing execution-time governance as a first-class AI RMF implementation pattern (March 7, 2026). See [docs/position-papers/nist/](docs/position-papers/nist/).
 
 [14] Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: https://www.openpolicyagent.org\
+
+[15] European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 of the European Parliament and of the Council of 13 June 2024 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, vol. 67, OJ L, 12 Jul. 2024. [Online]. Available: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202401689\
+**Relevance to AEGIS:** Primary EU regulatory framework for AI. While NIST AI RMF [13] is the technical governance framework AEGIS is built against, the EU AI Act is the regulatory environment AEGIS-governed systems must satisfy. Architectural enforcement at runtime (AEGIS's posture) directly supports mandatory conformity requirements under the Act. Most relevant to whitepaper, sponsor copy, and regulatory alignment documentation for EU-market enterprises and public institutions.
 **Relevance to AEGIS:** Proven policy engine pattern referenced in AGP-1 and AEGIS_Reference_Architecture.md. POLYNIX [8] validates OPA at scale (<1% CPU overhead, <2s policy propagation), directly supporting AEGIS's policy engine design decisions.
 
 ---
@@ -88,4 +91,5 @@ When citing in a document:
 
 **Part of**: AEGIS™ Documentation\
 **Maintained by**: AEGIS™ Initiative\
-**Last Updated**: 2026-03-13
+**Last Updated**: 2026-03-13\
+**Entries**: 15

--- a/claude-project/aegis-instructions-and-vision.yaml
+++ b/claude-project/aegis-instructions-and-vision.yaml
@@ -170,9 +170,21 @@ key_prior_art:
     relevance: Security automata theory; foundation for constitutional enforcement
 
   - shortname: NIST AI RMF 2023
-    title: AI Risk Management Framework (AI RMF 1.0)
-    publisher: NIST
+    title: "Artificial Intelligence Risk Management Framework (AI RMF 1.0)"
+    citation: 'National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Washington, DC, Jan. 2023, doi: 10.6028/NIST.AI.100-1.'
+    publisher: U.S. Department of Commerce / NIST
+    doi: 10.6028/NIST.AI.100-1
     relevance: Standards framework; AEGIS submitted unsolicited position paper 2026-03-07
+
+  - shortname: EU AI Act 2024
+    title: "Regulation (EU) 2024/1689 — Artificial Intelligence Act"
+    citation: 'European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 ... (Artificial Intelligence Act)," Official Journal of the European Union, vol. 67, OJ L, 12 Jul. 2024.'
+    canonical_identifier: "Regulation (EU) 2024/1689"
+    doi_url: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202401689
+    relevance: >
+      Regulatory environment AEGIS-governed systems must satisfy. Distinct from NIST AI RMF
+      (technical framework) — EU AI Act is the compliance mandate. Most relevant to whitepaper,
+      sponsor copy, and regulatory alignment docs for EU-market enterprises.
 
 ---
 


### PR DESCRIPTION
## Summary

- **REFERENCES.md [13]**: Corrected NIST AI RMF citation — adds formal publisher (U.S. Department of Commerce), DOI (`10.6028/NIST.AI.100-1`), and stable DOI URL. Prior entry pointed to the NIST ITL landing page, which is version-ambiguous; DOI pins to AI RMF 1.0 specifically.
- **REFERENCES.md [15]**: Added EU AI Act (Regulation (EU) 2024/1689) as new Standards & Frameworks entry. Canonical identifier is the regulation number; citation points to EUR-Lex (official EU legal portal), not secondary sites. Relevance note distinguishes it from NIST AI RMF: NIST is the technical governance framework; EU AI Act is the regulatory environment AEGIS-governed systems must satisfy.
- **claude-project/aegis-instructions-and-vision.yaml**: Synced both changes to the Claude.ai project file.

## Notes

- EU AI Act sits differently than NIST AI RMF in the bibliography — regulatory, not technical standard. Most relevant to whitepaper, sponsor copy, and regulatory alignment docs for EU-market enterprises.
- Canonical identifier for the EU AI Act: **Regulation (EU) 2024/1689** (not just "EU AI Act").
- Citation date follows IEEE convention: publication date (12 Jul. 2024), not adoption date (13 Jun. 2024).

## Test plan

- [ ] Verify `REFERENCES.md` [13] citation renders correctly with DOI
- [ ] Verify [15] entry is sequentially numbered and section-correctly placed
- [ ] Verify YAML is valid YAML (no syntax errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)