### PR TITLE
Docs(agp1): add RFC 8705 certificate-bound token auth

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -83,6 +83,10 @@ See [CLAUDE.md](CLAUDE.md) for citation format conventions.
 **Keywords:** Zero trust architecture; ZTA; identity verification; dynamic policy; microsegmentation; least privilege\
 **Relevance to AEGIS:** Canonical definitional reference for zero-trust architecture. AEGIS implements the four core ZTA tenets from §2 directly: (1) all resources must be authenticated before access is granted → AGP-1 actor identity requirement; (2) access is determined by dynamic policy → AGP-1 capability registry and policy engine; (3) all communication is secured regardless of network location → AGP-1 mTLS requirement; (4) all resource access is logged and inspected → AEGIS immutable audit trail. The §3 logical components model (policy engine, policy administrator, policy enforcement point) maps directly to the AGP-1 architecture. POLYNIX [8] validates these ZTA principles empirically; SP 800-207 is the definitional reference reviewers expect to see cited alongside POLYNIX. Public domain — may be quoted directly.
 
+[18] B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. [Online]. Available: https://www.rfc-editor.org/rfc/rfc8705\
+**Keywords:** OAuth 2.0; mTLS; certificate-bound tokens; client authentication; `cnf` claim; token binding\
+**Relevance to AEGIS:** Normative specification for AGP-1's combined JWT + mTLS authentication model. RFC 8705 defines how a client certificate at the TLS layer is cryptographically bound to an access token via the `cnf` (confirmation) claim — the token can only be used by the client holding the corresponding private key. This binding directly closes ATM-1's T3 (Identity Spoofing) and AV-1.4 (Token/Credential Theft) vectors: an intercepted token is useless without the certificate. RFC 7519 (JWT format) is the secondary reference if a reader needs the JWT structure definition; RFC 8705 is the primary citation wherever AGP-1 authentication is invoked.
+
 ---
 
 ## How to Cite
@@ -99,4 +103,4 @@ When citing in a document:
 **Part of**: AEGIS™ Documentation\
 **Maintained by**: AEGIS™ Initiative\
 **Last Updated**: 2026-03-13\
-**Entries**: 17
+**Entries**: 18

--- a/aegis-core/protocol/AEGIS_AGP1_AUTHENTICATION.md
+++ b/aegis-core/protocol/AEGIS_AGP1_AUTHENTICATION.md
@@ -51,6 +51,7 @@ Every AGP-1 message requires authentication proving the client's identity. Three
 | `scope` | string | yes | Space-separated OAuth scopes (see below) |
 | `actor_type` | string | yes | Type of actor: `ai_system`, `human_user`, `automated_system` |
 | `trust_level` | string | no | Actor's baseline trust level (from AEGIS_TRUST_MODEL): L0_SYSTEM, L1_PRIMARY, L2_TRUSTED, L3_CONTRIBUTOR, QUARANTINE |
+| `cnf` | object | no | Confirmation claim (RFC 8705 §3.1) — binds token to client certificate thumbprint. Required when using certificate-bound tokens. Example: `{"x5t#S256": "<SHA-256 cert thumbprint>"}` |
 
 ### Authorization Scopes
 
@@ -162,6 +163,70 @@ Server grants scopes from database:
   governance:propose_action
   governance:query_audit
 ```
+
+---
+
+## Certificate-Bound Tokens (RFC 8705)
+
+**Method**: `bearer_token` + `mtls` combined (Recommended for high-security deployments)\
+**Standard**: OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens [^18]
+
+In standard Bearer token authentication, a stolen token can be replayed by any party. Certificate-bound tokens close this gap: the JWT access token is cryptographically bound to the client's mTLS certificate via the `cnf` (confirmation) claim. A server that validates both the token signature and the certificate binding ensures the token can only be used by the client holding the corresponding private key.
+
+This mechanism directly mitigates ATM-1 T3 (Identity Spoofing) and AV-1.4 (Token/Credential Theft): an attacker who intercepts a token cannot use it without also compromising the client certificate.
+
+### How Certificate Binding Works
+
+```
+1. Client requests token from OAuth provider over mTLS
+2. OAuth provider computes SHA-256 thumbprint of client's TLS certificate
+3. Provider embeds thumbprint in JWT as cnf claim:
+      "cnf": { "x5t#S256": "<base64url(SHA-256(client_cert_DER))>" }
+4. Client presents token + same certificate to AGP-1 server
+5. Server validates:
+      a. JWT signature and claims (standard validation)
+      b. mTLS certificate is valid
+      c. cnf.x5t#S256 in JWT matches SHA-256 of presented certificate
+      → Stolen token + different certificate = REJECT
+```
+
+### JWT with Certificate Binding
+
+```json
+{
+  "alg": "RS256",
+  "typ": "JWT",
+  "kid": "key-v1"
+}
+.
+{
+  "iss": "https://auth.example.com",
+  "sub": "agent:soc-001",
+  "aud": "https://governance.example.com",
+  "iat": 1709624400,
+  "exp": 1709628000,
+  "scope": "governance:propose_action",
+  "actor_type": "ai_system",
+  "trust_level": "L2_TRUSTED",
+  "cnf": {
+    "x5t#S256": "bwcK0esc3ACC3DB2Y5_lESsXE8o9ltc05O89jdN-dg"
+  }
+}
+```
+
+### Server Validation (Additional Step)
+
+After standard JWT validation (steps 1–7 above), when `cnf` is present:
+
+```python
+# Step 8: Verify certificate binding (RFC 8705 §3.1)
+if "cnf" in auth_token and "x5t#S256" in auth_token["cnf"]:
+    cert_thumbprint = base64url(sha256(tls_client_cert_der))
+    if cert_thumbprint != auth_token["cnf"]["x5t#S256"]:
+        raise Unauthorized("certificate binding mismatch — possible token theft")
+```
+
+[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. See [REFERENCES.md](../../REFERENCES.md).
 
 ---
 
@@ -330,6 +395,7 @@ If token must be revoked before expiration (compromise):
 - ✅ Maintain audit log of authentication events
 - ✅ Rotate signing keys regularly (quarterly minimum)
 - ✅ Verify issuer is trusted (don't accept unknown issuers)
+- ✅ In high-security deployments, require certificate-bound tokens (RFC 8705) and validate `cnf.x5t#S256` against the presented mTLS certificate — prevents token theft (ATM-1 AV-1.4)
 
 ---
 


### PR DESCRIPTION
## Summary

Two-file change — reference and spec are coupled and belong together.

### REFERENCES.md [18]
Added Campbell et al. 2020, **RFC 8705 — OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens**. Relevance note: normative spec for AGP-1's combined JWT + mTLS model; closes ATM-1 T3/AV-1.4 (token theft); distinction from RFC 7519 (JWT format — secondary reference only).

### AEGIS_AGP1_AUTHENTICATION.md

**Gap closed**: The prior spec described JWT and mTLS as two separate, independent mechanisms. RFC 8705 defines how they work *in combination* — the access token is cryptographically bound to the client certificate. A stolen token is useless without the certificate. This was missing.

**Three targeted additions (no existing text changed):**

1. **JWT Claims table** — added optional `cnf` claim row: RFC 8705 §3.1 confirmation claim; SHA-256 certificate thumbprint; required when using certificate-bound tokens

2. **New section: "Certificate-Bound Tokens (RFC 8705)"** between mTLS and API Key sections:
   - Explains the token theft threat and how binding closes it
   - Step-by-step binding flow (how `cnf.x5t#S256` is computed and verified)
   - JWT example with `cnf` claim
   - Python server validation Step 8 (appended to the standard 7-step validation)
   - Inline footnote `[^18]`
   - ATM-1 T3 / AV-1.4 cross-reference

3. **Best Practices (server)** — added bullet: require `cnf` validation in high-security deployments with explicit AV-1.4 reference

## What was NOT changed

- Error codes (AGP-AUTH-001 through 004)
- Identity propagation requirement
- API key warning/deprecation notice
- Overall document structure

## Test plan

- [ ] New section renders correctly in GitHub Markdown
- [ ] `cnf` claim row appears in JWT Claims table
- [ ] Footnote `[^18]` resolves
- [ ] REFERENCES.md [18] is sequentially numbered

🤖 Generated with [Claude Code](https://claude.com/claude-code)