### PR TITLE
Docs: correct Anderson 1972 [1] citation — issuing org and URL

### DIFF
--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -8,7 +8,7 @@ See [CLAUDE.md](CLAUDE.md) for citation format conventions.
 
 ## Foundational Security Theory
 
-[1] J. P. Anderson, "Computer Security Technology Planning Study," Technical Report ESD-TR-73-51, The MITRE Corporation, Air Force Electronic Systems Division, Hanscom AFB, Bedford, MA, Oct. 1972, Vols. I and II. [Online]. Available: https://csrc.nist.gov/publications/history/ande72.pdf\
+[1] J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. [Online]. Available: https://csrc.nist.gov/files/pubs/conference/1998/10/08/proceedings-of-the-21st-nissc-1998/final/docs/early-cs-papers/ande72.pdf\
 **Relevance to AEGIS:** First articulation of the reference monitor — a component that validates all references made by executing programs against those authorized for the subject. The conceptual origin of every enforcement boundary AEGIS inherits. AEGIS's governance gateway is a direct descendant of this concept.
 
 [2] F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382.\


### PR DESCRIPTION
## Summary

Two factual corrections to REFERENCES.md [1] (Anderson 1972 — the reference monitor paper):

**1. Issuing organization corrected**
- Was: `The MITRE Corporation, Air Force Electronic Systems Division`
- Now: `Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC)`

MITRE is a separate contractor organization. The report was issued by HQ ESD/AFSC (Hanscom Field) under contract F19628-72-C-0198. Anderson was the author, not a MITRE employee on this report.

**2. URL corrected**
- Was: `https://csrc.nist.gov/publications/history/ande72.pdf` (a landing page reference, not a direct PDF link)
- Now: `https://csrc.nist.gov/files/pubs/conference/1998/10/08/proceedings-of-the-21st-nissc-1998/final/docs/early-cs-papers/ande72.pdf` (direct PDF, stable NISSC 1998 proceedings path)

**3. Volume clarified**
- Was: `Vols. I and II`
- Now: `Vol. II` — the hosted PDF is Volume II, which is the volume containing the reference monitor concept discussion

## Test plan

- [ ] URL resolves to the Anderson 1972 PDF
- [ ] Issuing org matches standard security literature citations

🤖 Generated with [Claude Code](https://claude.com/claude-code)