### PR TITLE
Fix(structure): move [^18] to ## References section at end of AEGIS_AGP1_AUTHENTICATION.md

### DIFF
--- a/aegis-core/protocol/AEGIS_AGP1_AUTHENTICATION.md
+++ b/aegis-core/protocol/AEGIS_AGP1_AUTHENTICATION.md
@@ -226,8 +226,6 @@ if "cnf" in auth_token and "x5t#S256" in auth_token["cnf"]:
         raise Unauthorized("certificate binding mismatch — possible token theft")
 ```
 
-[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. See [REFERENCES.md](../../REFERENCES.md).
-
 ---
 
 ## API Key Authentication  (Deprecated; Sunset: 2026-12-31)
@@ -403,3 +401,9 @@ If token must be revoked before expiration (compromise):
 
 - [AGP1_PolicyEvaluation.md](./AGP1_PolicyEvaluation.md) - Capability and policy evaluation
 - [AGP1_Flows.md](./AGP1_Flows.md) - Complete protocol flows
+
+---
+
+## References
+
+[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. See [REFERENCES.md](../../REFERENCES.md).


### PR DESCRIPTION
## Summary

- The `[^18]` footnote definition for RFC 8705 was embedded mid-document (after the Certificate-Bound Tokens code block, line 229), before `## API Key Authentication` and `## Next Steps`
- GitHub renders footnote definitions at the very bottom of the rendered page regardless of where they appear in source, so the footnote appeared after `## Next Steps` with no `## References` heading
- This PR moves the definition to a proper `## References` section after `## Next Steps`, consistent with all other cited documents in the repository

## Test plan

- [ ] Markdownlint passes
- [ ] Spellcheck passes
- [ ] `[^18]` inline reference in Certificate-Bound Tokens section still renders as clickable superscript

🤖 Generated with [Claude Code](https://claude.com/claude-code)