### PR TITLE
Fix(RFC-0004): align trust formula with GFN-1 §3.7, remove cold-start note (v0.3)

### DIFF
--- a/rfc/RFC-0004-Governance-Event-Model.md
+++ b/rfc/RFC-0004-Governance-Event-Model.md
@@ -98,7 +98,7 @@ Where:
 
 - **B** — Baseline Trust Factor (identity class and credential strength)
 - **H** — Historical Accuracy Factor (fraction of signals not subsequently contradicted)
-- **Q** — Evidence Quality Factor (signal completeness and confidence calibration)
+- **Q** — Consistency and Quality Factor (signal completeness and confidence calibration)
 - **A** — Audit Posture Factor (operational governance maturity)
 - **F** — Federation Reputation Factor (peer node endorsements)
 


### PR DESCRIPTION
Closes #35

## Summary

- **§5 Trust Evaluation Model**: replaces misaligned weights (`0.25/0.20/0.25/0.15/0.15`) with the GFN-1 §3.7 normative formula `T = 0.30B + 0.25H + 0.20Q + 0.15A + 0.10F`; renames components to canonical factor names (B/H/Q/A/F) with inline definitions
- **Q factor name corrected**: "Evidence Quality Factor" → "Consistency and Quality Factor" to match GFN-1 §3.4 exactly
- **Bootstrap note added**: `T` clamped to [0.0, 1.0]; bootstrap values for new nodes deferred to GFN-1 §3.2–§3.6
- **Drawbacks**: cold-start description replaced with reference to GFN-1 §5 bootstrap mechanisms
- **Implementation Notes**: cold-start operational note replaced with reference to GFN-1 §5 (allowlist, consortium membership, transitive endorsement, accelerated onboarding)
- **Version bump**: 0.2 → 0.3; updated date 2026-03-15

## Test plan

- [ ] §5 formula weights sum to 1.0 (0.30 + 0.25 + 0.20 + 0.15 + 0.10 = 1.00 ✓)
- [ ] Component names B/H/Q/A/F and full factor names match GFN-1 §3.2–§3.6 definitions (Q = "Consistency and Quality Factor") ✓
- [ ] Cold-start language removed from Drawbacks and Implementation Notes
- [ ] GFN-1 §5 reference resolves correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)