### PR TITLE
Fix(gitignore): exclude docs/papers/ from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ env/
 # Local working directories
 .claude/
 resources/
+docs/papers/
 
 # AEGIS runtime artifacts
 .aegis/audit.jsonl


### PR DESCRIPTION
## Description

Adds `docs/papers/` to `.gitignore` to prevent IEEE paper drafts from being pushed to the public repository.

## Motivation

Paper drafts are pre-submission working documents. Premature publication of the IEEE draft before submission is not appropriate.

## Type of Change

- [x] Bug fix

## Related Issues

N/A

## Changes Made

- `.gitignore`: added `docs/papers/` exclusion pattern

## Testing

- [x] Markdown linting passes
- [x] Spell check passes

## Documentation Updates

- [ ] README updated (if needed)
- [ ] RFC documentation updated (if applicable)
- [ ] Code comments added/updated
- [ ] CHANGELOG updated (for runtime changes)
- [ ] Specification version numbers updated (if applicable)

## Specification Impact

- [x] No specification version impact

## Security Considerations

- [x] No security impact

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Branch follows naming convention (`rfc/`, `docs/`, `spec/`, `feat/`, `fix/`)
- [x] Commits follow Conventional Commits format
- [x] Self-review completed
- [x] PR is ready for review