### PR TITLE
chore: align ATX-1 dataset metadata with v2.2 for IEEE DataPort

### DIFF
--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -28,6 +28,8 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 | ATX-1 v2.0 Source Repository Snapshot | Zenodo | [10.5281/zenodo.19238844](https://doi.org/10.5281/zenodo.19238844) | 2026-03-26 |
 | ATX-1 v2.1 Source Repository Snapshot | Zenodo | [10.5281/zenodo.19251098](https://doi.org/10.5281/zenodo.19251098) | 2026-03-27 |
 | ATX-1 v2.1: AEGIS Threat Matrix (dataset) | IEEE DataPort | [10.21227/015v-9641](https://doi.org/10.21227/015v-9641) | 2026-03-30 |
+| ATX-1 v2.2 Source Repository Snapshot | Zenodo | [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999) | 2026-04-01 |
+| ATX-1 v2.2: AEGIS Threat Matrix (dataset) | IEEE DataPort | [10.21227/7c9p-6150](https://doi.org/10.21227/7c9p-6150) | 2026-04-09 |
 
 ## Archived Repositories
 

--- a/docs/atx/README.md
+++ b/docs/atx/README.md
@@ -23,7 +23,7 @@ This directory contains the ATX-1 technique taxonomy, a structured adversarial k
 - [v2/data/atx-1-techniques.json](v2/data/atx-1-techniques.json) — All 29 techniques as structured JSON
 - [v2/data/atx-1-regulatory-crossref.json](v2/data/atx-1-regulatory-crossref.json) — Regulatory cross-reference matrix
 - [v2/data/atx-1-navigator-layer.json](v2/data/atx-1-navigator-layer.json) — ATT&CK Navigator layer
-- [v2/data/atx-1-version-mapping.json](v2/data/atx-1-version-mapping.json) — Version mapping (v1.0 → v2.1)
+- [v2/data/atx-1-version-mapping.json](v2/data/atx-1-version-mapping.json) — Version mapping (v1.0 → v2.2)
 - [v2/data/atx-1-atm1-mapping.json](v2/data/atx-1-atm1-mapping.json) — ATX-1 ↔ ATM-1 mapping
 - [v2/data/atx-1-validation-aegis-core.json](v2/data/atx-1-validation-aegis-core.json) — aegis-core red/blue team validation results
 

--- a/docs/atx/v2/data/atx-1-atm1-mapping.json
+++ b/docs/atx/v2/data/atx-1-atm1-mapping.json
@@ -3,8 +3,17 @@
   "artifact": "ATX-1-MAP",
   "version": "0.2",
   "generated": "2026-04-01",
-  "description": "Mapping of ATX-1 v2.0 techniques to ATM-1 attack vectors, controls, and detection signals (v0.2: bumped for ATX-1 v2.2 release; TA010 technique mappings deferred to follow-up — see ACF-1 entries for control coverage.)",
+  "description": "Mapping of ATX-1 techniques to ATM-1 attack vectors, controls, and detection signals. Aligned with ATX-1 v2.2.",
   "license": "CC-BY-SA-4.0",
+  "coverage": {
+    "atx_version": "2.2",
+    "covered_tactics": ["TA001", "TA002", "TA003", "TA004", "TA005", "TA006", "TA007", "TA008", "TA009"],
+    "deferred": {
+      "tactics": ["TA010"],
+      "techniques": ["T10001", "T10002", "T10003", "T10004"],
+      "reason": "TA010 (Bypass Governance Controls) technique-level ATM-1 vector mappings deferred to v0.3. Control coverage for TA010 is provided via ACF-1 entries; see aegis-governance/docs/acf for the ACF-1 catalog."
+    }
+  },
   "mappings": [
     {
       "atx_id": "T1001",

--- a/docs/atx/v2/data/atx-1-validation-aegis-core.json
+++ b/docs/atx/v2/data/atx-1-validation-aegis-core.json
@@ -3,7 +3,7 @@
   "artifact": "ATX-1-VALIDATION",
   "version": "1.1",
   "generated": "2026-03-30",
-  "description": "Empirical validation of ATX-1 v2.1 against aegis-core reference implementation via adversarial red/blue team testing",
+  "description": "Empirical validation of ATX-1 v2.1 baseline (10 tactics, 29 top-level techniques) against aegis-core reference implementation via adversarial red/blue team testing. Note: v2.2 sub-techniques under T9002 and T10001–T10004 are catalog refinements derived from the same adversarial corpus and inherit this validation; a dedicated v2.2 sub-technique revalidation pass is planned for the next release.",
   "license": "CC-BY-SA-4.0",
   "doi": "10.5281/zenodo.19342905",
   "doi_all_versions": "10.5281/zenodo.19342904",


### PR DESCRIPTION
## Summary

Pre-upload audit for the ATX-1 v2.2 IEEE DataPort dataset surfaced four metadata inconsistencies. This PR fixes them so the published artifacts are self-disclosing and internally consistent.

- **README** — version-mapping file label corrected from v2.1 → v2.2
- **`atx-1-validation-aegis-core.json`** — description now explicitly states v2.1 baseline scope (10 tactics, 29 top-level techniques), clarifies that v2.2 sub-techniques inherit from the same adversarial corpus, and flags a dedicated v2.2 sub-technique revalidation pass for the next release
- **`atx-1-atm1-mapping.json`** — replaced prose disclosure with a structured `coverage` block: `atx_version: 2.2`, the 9 fully covered tactics, and a `deferred` field listing TA010 + T10001–T10004 with rationale (control coverage via ACF-1)
- **`PUBLICATIONS.md`** — recorded the two missing v2.2 DOIs:
  - Zenodo source snapshot: [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999)
  - IEEE DataPort dataset: [10.21227/7c9p-6150](https://doi.org/10.21227/7c9p-6150) (live as of 2026-04-09)

The DataPort upload at https://ieee-dataport.org/documents/atx-1-v22-aegis-threat-matrix-agentic-ai-systems is already live; this PR brings the source repo into alignment with the published metadata.

## Test plan

- [x] Both edited JSON files parse via `json.load`
- [x] No content/structure changes — only metadata fields
- [ ] CI green (markdownlint, spellcheck, JSON schema validation)