### PR TITLE
docs: use markdown hard line breaks in metadata blocks

### DIFF
--- a/docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md
+++ b/docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md
@@ -2,11 +2,11 @@
 
 ## Adversarial Knowledge Base for Agentic AI Actor Behavior
 
-**Version:** 2.2.0
-**Date:** 2026-04-01
+**Version:** 2.2.0\
+**Date:** 2026-04-01\
 **Status:** Active — v2.2 adds 29 sub-techniques under T9002 and T10001–T10004
-cataloging specific bypass methods discovered during RFC-0006 adversarial testing.
-**Maintainer:** AEGIS Initiative — Finnoybu IP LLC
+cataloging specific bypass methods discovered during RFC-0006 adversarial testing.\
+**Maintainer:** AEGIS Initiative — Finnoybu IP LLC\
 **License:** CC-BY-SA-4.0
 
 ---

--- a/docs/position-papers/ieee-tnse-2026/AoC-Lab-Executive-Summary.md
+++ b/docs/position-papers/ieee-tnse-2026/AoC-Lab-Executive-Summary.md
@@ -1,9 +1,9 @@
 # AEGIS AoC Laboratory Experiment — Executive Summary
 
-**Date:** April 8, 2026
-**Duration:** ~6 hours (ungoverned phase: ~3 hours, governed phase: ~1 hour, setup/transitions: ~2 hours)
-**Principal Investigator:** Kenneth Tannenbaum, AEGIS Initiative
-**Infrastructure:** AEGIS Server (dual Xeon Silver 4116, 251GB RAM, RTX 5060 Ti, Debian 13)
+**Date:** April 8, 2026  
+**Duration:** ~6 hours (ungoverned phase: ~3 hours, governed phase: ~1 hour, setup/transitions: ~2 hours)  
+**Principal Investigator:** Kenneth Tannenbaum, AEGIS Initiative  
+**Infrastructure:** AEGIS Server (dual Xeon Silver 4116, 251GB RAM, RTX 5060 Ti, Debian 13)  
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds trailing backslashes (ATX-1 taxonomy) and trailing double-spaces (AoC executive summary) to metadata header lines so each field renders on its own line instead of being collapsed into a single paragraph by markdown's soft-wrap rules.
- Pure rendering fix; no content changes.

## Test plan

- [ ] CI green (markdownlint, spellcheck)
- [ ] Visual check that metadata blocks render as separate lines