### PR TITLE
docs: mark IEEE Data Descriptions descriptor as submitted (v0.4)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -172,6 +172,8 @@
     "TDSC",
     "thicketing",
     "TISSEC",
+    "TNSE",
+    "TNSEJL",
     "Torgbi",
     "Tpte",
     "Ukil",

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -7,7 +7,8 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 | Title | Venue | Status | Manuscript ID | DOI | Date |
 |---|---|---|---|---|---|
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents | IEEE Computer (SI: AI Governance and Compliance) | Under Review | COMSI-2026-03-0087 | — | 2026-03-25 |
-| Descriptor: AEGIS Threat Matrix for Agentic AI Systems (ATX-1) | IEEE Data Descriptions | Submitted | — | — | 2026-03-26 |
+| Descriptor: AEGIS Threat Matrix for Agentic AI Systems (ATX-1) | IEEE Data Descriptions | Under Review | DATA-00033-2026 | — | 2026-03-26 |
+| AEGIS: Reference Monitor–Based Governance with Federated Trust for Autonomous Edge AI Agents | IEEE TNSE (SI: Secure, Trustworthy, and Autonomous Intelligent Edge Networking with Agentic AI) | Rejected (2026-04-08, Editorial Office) | TNSEJL-2026-04-1062 | — | 2026-04-08 |
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents (Preprint) | Zenodo | Published | — | [10.5281/zenodo.19223924](https://doi.org/10.5281/zenodo.19223924) | 2026-03-25 |
 
 ## Position Papers & Submissions

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -19,6 +19,12 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 | AEGIS NCCoE AI Agent Identity & Authorization Response | NCCoE | Submitted | 2026-03-22 |
 | AEGIS CETS225 Positioning | CETS225 | Submitted | 2026-03 |
 
+## Books & Ebooks
+
+| Title | Publisher | DOI | Date |
+|---|---|---|---|
+| Governing the Action Boundary: An open architecture for autonomous AI agents | AEGIS Initiative · Finnoybu IP LLC | [10.5281/zenodo.19489150](https://zenodo.org/records/19489150) | 2026-04-09 |
+
 ## Datasets
 
 | Title | Repository | DOI | Date |

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -8,7 +8,7 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 |---|---|---|---|---|---|
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents | IEEE Computer (SI: AI Governance and Compliance) | Under Review | COMSI-2026-03-0087 | — | 2026-03-25 |
 | Descriptor: AEGIS Threat Matrix for Agentic AI Systems (ATX-1) | IEEE Data Descriptions | Under Review | DATA-00033-2026 | — | 2026-03-26 |
-| AEGIS: Reference Monitor–Based Governance with Federated Trust for Autonomous Edge AI Agents | IEEE TNSE (SI: Secure, Trustworthy, and Autonomous Intelligent Edge Networking with Agentic AI) | Rejected (2026-04-08, Editorial Office) | TNSEJL-2026-04-1062 | — | 2026-04-08 |
+| AEGIS: Reference Monitor–Based Governance with Federated Trust for Autonomous Edge AI Agents | IEEE TNSE (SI: Secure, Trustworthy, and Autonomous Intelligent Edge Networking with Agentic AI) | Resubmission Invited (desk-rejected 2026-04-08; appeal granted by EIC 2026-04-09) | TNSEJL-2026-04-1062 (original) | — | 2026-04-08 |
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents (Preprint) | Zenodo | Published | — | [10.5281/zenodo.19223924](https://doi.org/10.5281/zenodo.19223924) | 2026-03-25 |
 
 ## Position Papers & Submissions

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -8,7 +8,7 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 |---|---|---|---|---|---|
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents | IEEE Computer (SI: AI Governance and Compliance) | Under Review | COMSI-2026-03-0087 | — | 2026-03-25 |
 | Descriptor: AEGIS Threat Matrix for Agentic AI Systems (ATX-1) | IEEE Data Descriptions | Under Review | DATA-00033-2026 | — | 2026-03-26 |
-| AEGIS: Reference Monitor–Based Governance with Federated Trust for Autonomous Edge AI Agents | IEEE TNSE (SI: Secure, Trustworthy, and Autonomous Intelligent Edge Networking with Agentic AI) | Resubmission Invited (desk-rejected 2026-04-08; appeal granted by EIC 2026-04-09) | TNSEJL-2026-04-1062 (original) | — | 2026-04-08 |
+| AEGIS: Reference Monitor–Based Governance with Federated Trust for Autonomous Edge AI Agents | IEEE TNSE (SI: Secure, Trustworthy, and Autonomous Intelligent Edge Networking with Agentic AI) | Resubmitted at EIC invitation (orig. desk-rejected 2026-04-08; appeal granted 2026-04-09) | 213562c7-09ca-4b49-bdab-aca9c091fdf6 (new); TNSEJL-2026-04-1062 (original) | — | 2026-04-09 |
 | AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents (Preprint) | Zenodo | Published | — | [10.5281/zenodo.19223924](https://doi.org/10.5281/zenodo.19223924) | 2026-03-25 |
 
 ## Position Papers & Submissions

--- a/docs/position-papers/ieee-data-descriptions/FinnoybuIPLLC-AEGIS-IEEE-DataDescriptions-ATX1-ThreatMatrix-2026.md
+++ b/docs/position-papers/ieee-data-descriptions/FinnoybuIPLLC-AEGIS-IEEE-DataDescriptions-ATX1-ThreatMatrix-2026.md
@@ -1,15 +1,21 @@
 > **Document**: FinnoybuIPLLC-AEGIS-IEEE-DataDescriptions-ATX1-ThreatMatrix-2026.md\
-> **Version**: 0.3 (DRAFT)\
+> **Version**: 0.4 (final, as submitted)\
 > **Part of**: AEGIS Position Papers\
 > **Target Venue**: IEEE Data Descriptions\
 > **Article Type**: Descriptor\
 > **Author**: Kenneth Tannenbaum (AEGIS Initiative)\
 > **ORCID**: 0009-0007-4215-1789\
 > **Preprint DOI**: 10.5281/zenodo.19223924\
-> **Dataset DOI**: 10.21227/f87b-1d57
+> **Dataset DOI (as submitted)**: 10.21227/f87b-1d57 (ATX-1 v1.0)
 >
-> **DRAFT — NOT YET SUBMITTED**
-> This document is a working draft for submission to IEEE Data Descriptions.
+> **STATUS — SUBMITTED 2026-03-26**\
+> Submitted to IEEE Data Descriptions on 2026-03-26 as v0.4 (final).
+> Canonical submission artifact: [`submission/atx1-descriptor.tex`](submission/atx1-descriptor.tex) (LaTeX) and the accompanying PDF.
+> This markdown is the human-readable working copy of that submission and intentionally describes ATX-1 **v1.0** (9 tactics, 20 techniques) — the dataset state at submission time.
+>
+> **POST-SUBMISSION NOTE**\
+> The ATX-1 dataset has since evolved. The current release is **v2.2** (10 tactics, 29 techniques, 29 sub-techniques) with DOI [10.21227/7c9p-6150](https://doi.org/10.21227/7c9p-6150) on IEEE DataPort and [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999) on Zenodo. See [`docs/atx/README.md`](../../atx/README.md) for current state. This descriptor remains frozen at v1.0 to match the submitted record; a follow-on descriptor for v2.x is planned separately.
+>
 > Everything above this line is internal metadata and will not appear in the submission.
 
 ---
@@ -188,7 +194,7 @@ All storage locations serve identical file content under the Apache 2.0 license.
 
 ATX-1 v1.0 derives its technique definitions primarily from the *Agents of Chaos* study [4], with the core findings corroborated by independent research on multi-agent vulnerabilities [11], cross-domain security challenges [12], and governed system failure modes [13]. While the technique catalog may not be exhaustive, the convergence of multiple research groups on the same failure patterns provides confidence in the taxonomy's coverage of the dominant threat classes. Future versions will incorporate additional empirical sources as the field of agentic AI governance matures.
 
-The severity ratings reflect the authors' assessment based on the documented case studies and are not derived from a quantitative risk model. Organizations should calibrate severity ratings to their specific deployment context.
+The severity ratings reflect the author's assessment based on the documented case studies and are not derived from a quantitative risk model. Organizations should calibrate severity ratings to their specific deployment context.
 
 ### Extensibility
 

--- a/docs/position-papers/ieee-data-descriptions/FinnoybuIPLLC-AEGIS-IEEE-DataDescriptions-ATX1-ThreatMatrix-2026.md
+++ b/docs/position-papers/ieee-data-descriptions/FinnoybuIPLLC-AEGIS-IEEE-DataDescriptions-ATX1-ThreatMatrix-2026.md
@@ -8,8 +8,8 @@
 > **Preprint DOI**: 10.5281/zenodo.19223924\
 > **Dataset DOI (as submitted)**: 10.21227/f87b-1d57 (ATX-1 v1.0)
 >
-> **STATUS — SUBMITTED 2026-03-26**\
-> Submitted to IEEE Data Descriptions on 2026-03-26 as v0.4 (final).
+> **STATUS — UNDER REVIEW (Submitted 2026-03-26)**\
+> Submitted to IEEE Data Descriptions on 2026-03-26 as v0.4 (final). Manuscript ID: **DATA-00033-2026**. Currently under editorial review (verified 2026-04-09 via IEEE Author Portal).
 > Canonical submission artifact: [`submission/atx1-descriptor.tex`](submission/atx1-descriptor.tex) (LaTeX) and the accompanying PDF.
 > This markdown is the human-readable working copy of that submission and intentionally describes ATX-1 **v1.0** (9 tactics, 20 techniques) — the dataset state at submission time.
 >


### PR DESCRIPTION
## Summary

The IEEE Data Descriptions descriptor markdown header was stale: it still said "v0.3 DRAFT — NOT YET SUBMITTED" even though the article was submitted on 2026-03-26 as v0.4 final (commit baadf83).

This PR updates only the metadata header — the technical content (9 tactics, 20 techniques, ATX-1 v1.0 DOIs) is intentionally preserved to maintain fidelity with the actually-submitted PDF/LaTeX in `submission/atx1-descriptor.tex`.

### Changes
- **Header:** version 0.3 → 0.4 (final, as submitted), status flipped from "DRAFT" to "SUBMITTED 2026-03-26"
- **Pointer added** to the canonical submission artifact (`submission/atx1-descriptor.tex` + PDF)
- **Frozen-version note:** explicit statement that the descriptor describes ATX-1 **v1.0** to match the submission record
- **Post-submission note:** points readers to current ATX-1 v2.2 DOIs ([10.21227/7c9p-6150](https://doi.org/10.21227/7c9p-6150), [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999)) so the working copy isn't mistaken for current dataset state
- **Typo fix:** "authors' assessment" → "author's assessment" (single author)

### Why not bump to v2.2?
A descriptor article is a record of what was submitted. Rewriting it to describe v2.2 would falsify the submission record. A separate v2.x descriptor is the right path; this PR just makes the markdown faithfully reflect what was already sent to IEEE.

## Test plan
- [ ] CI green (markdownlint, spellcheck)
- [ ] Verify the post-submission note links resolve