### PR TITLE
docs: add canonical source notice to schemas README

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -252,7 +252,17 @@
     "underclaiming",
     "Overclaimed",
     "Solana",
-    "permissioned"
+    "permissioned",
+    "AIAM",
+    "aiam",
+    "IBAC",
+    "XACML",
+    "PBAC",
+    "Bertino",
+    "Byun",
+    "Rego",
+    "SACMAT",
+    "granularities"
   ],
   "ignorePaths": [
     "archive/**",

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -43,19 +43,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compile JSON Schemas with AJV
         run: |
-          npm install --no-save ajv-formats@3.0.1
+          npm install --no-save ajv-cli@5.0.0 ajv-formats@3.0.1
 
           # Compile common schemas first (no references)
           for schema in aegis-core/schemas/common/*.schema.json; do
             echo "Compiling $schema"
-            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" || exit 1
+            npx ajv-cli compile --spec=draft2020 -c ajv-formats -s "$schema" || exit 1
           done
 
           # Compile governance schemas with common references
           for schema in aegis-core/schemas/governance/*.schema.json; do
             [ -f "$schema" ] || continue
             echo "Compiling $schema"
-            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
+            npx ajv-cli compile --spec=draft2020 -c ajv-formats -s "$schema" \
               -r 'aegis-core/schemas/common/*.schema.json' || exit 1
           done
 
@@ -65,7 +65,7 @@ jobs:
               for schema in aegis-core/schemas/$dir/*.schema.json; do
                 [ -f "$schema" ] || continue
                 echo "Compiling $schema"
-                npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
+                npx ajv-cli compile --spec=draft2020 -c ajv-formats -s "$schema" \
                   -r 'aegis-core/schemas/common/*.schema.json' || exit 1
               done
             fi
@@ -76,7 +76,7 @@ jobs:
             for schema in aegis-core/schemas/governance/events/*.schema.json; do
               [ -f "$schema" ] || continue
               echo "Compiling $schema"
-              npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
+              npx ajv-cli compile --spec=draft2020 -c ajv-formats -s "$schema" \
                 -r 'aegis-core/schemas/common/*.schema.json' \
                 -r 'aegis-core/schemas/governance/*.schema.json' || exit 1
             done
@@ -84,32 +84,32 @@ jobs:
 
       - name: Validate example payloads with AJV
         run: |
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/action_propose.schema.json \
             -d aegis-core/schemas/examples/agp/action_propose.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/decision_response.schema.json \
             -d aegis-core/schemas/examples/agp/decision_response.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/execution_result.schema.json \
             -d aegis-core/schemas/examples/agp/execution_result.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/escalation_request.schema.json \
             -d aegis-core/schemas/examples/agp/escalation_request.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/capability/capability.schema.json \
             -d aegis-core/schemas/examples/capability/capability.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
+          npx ajv-cli validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/governance/events/policy_update.schema.json \
             -d aegis-core/schemas/examples/governance/policy_update.example.json \
             -r 'aegis-core/schemas/common/*.schema.json' \

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -43,17 +43,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compile JSON Schemas with AJV
         run: |
+          npm install --no-save ajv-formats@3.0.1
+
           # Compile common schemas first (no references)
           for schema in aegis-core/schemas/common/*.schema.json; do
             echo "Compiling $schema"
-            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -s "$schema" || exit 1
+            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" || exit 1
           done
 
           # Compile governance schemas with common references
           for schema in aegis-core/schemas/governance/*.schema.json; do
             [ -f "$schema" ] || continue
             echo "Compiling $schema"
-            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -s "$schema" \
+            npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
               -r 'aegis-core/schemas/common/*.schema.json' || exit 1
           done
 
@@ -63,7 +65,7 @@ jobs:
               for schema in aegis-core/schemas/$dir/*.schema.json; do
                 [ -f "$schema" ] || continue
                 echo "Compiling $schema"
-                npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -s "$schema" \
+                npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
                   -r 'aegis-core/schemas/common/*.schema.json' || exit 1
               done
             fi
@@ -74,7 +76,7 @@ jobs:
             for schema in aegis-core/schemas/governance/events/*.schema.json; do
               [ -f "$schema" ] || continue
               echo "Compiling $schema"
-              npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -s "$schema" \
+              npx --yes ajv-cli@5.0.0 compile --spec=draft2020 -c ajv-formats -s "$schema" \
                 -r 'aegis-core/schemas/common/*.schema.json' \
                 -r 'aegis-core/schemas/governance/*.schema.json' || exit 1
             done
@@ -82,32 +84,32 @@ jobs:
 
       - name: Validate example payloads with AJV
         run: |
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/action_propose.schema.json \
             -d aegis-core/schemas/examples/agp/action_propose.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/decision_response.schema.json \
             -d aegis-core/schemas/examples/agp/decision_response.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/execution_result.schema.json \
             -d aegis-core/schemas/examples/agp/execution_result.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/agp/escalation_request.schema.json \
             -d aegis-core/schemas/examples/agp/escalation_request.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/capability/capability.schema.json \
             -d aegis-core/schemas/examples/capability/capability.example.json \
             -r 'aegis-core/schemas/common/*.schema.json'
 
-          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 \
+          npx --yes ajv-cli@5.0.0 validate --spec=draft2020 -c ajv-formats \
             -s aegis-core/schemas/governance/events/policy_update.schema.json \
             -d aegis-core/schemas/examples/governance/policy_update.example.json \
             -r 'aegis-core/schemas/common/*.schema.json' \

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ REQUIRE_CONFIRMATION
 
 This ensures that all operational actions are subject to **deterministic governance enforcement**.
 
+The canonical editable JSON Schemas for cross-repository AEGIS contracts live in
+[`aegis`](https://github.com/aegis-initiative/aegis) under `schemas/`. Any schema copies, examples, or mirrors in this
+repository should be treated as public technical documentation or synchronized artifacts rather than an independent
+source of truth.
+
 ---
 
 # AEGIS Federation Network

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -133,7 +133,7 @@ Changes in one layer may require updates in dependent layers. Protocol changes (
 |---|---|---|---|
 | Understand AEGIS concept | [Manifesto](aegis-core/manifesto/AEGIS_Manifesto.md) | [System Overview](aegis-core/overview/AEGIS_System_Overview.md) | [FAQ](aegis-core/faq/AEGIS_FAQ.md) |
 | Evaluate governance model | [System Overview](aegis-core/overview/AEGIS_System_Overview.md) | [Reference Architecture](aegis-core/architecture/AEGIS_Reference_Architecture.md) | [Threat Model](aegis-core/threat-model/AEGIS_ATM1_INDEX.md) |
-| Design implementation | [Reference Architecture](aegis-core/architecture/AEGIS_Reference_Architecture.md) | [AGP-1 Protocol](aegis-core/protocol/AEGIS_AGP1_INDEX.md) | [Schemas](aegis-core/schemas/) |
+| Design implementation | [Reference Architecture](aegis-core/architecture/AEGIS_Reference_Architecture.md) | [AGP-1 Protocol](aegis-core/protocol/AEGIS_AGP1_INDEX.md) | [Canonical Schemas](https://github.com/aegis-initiative/aegis/tree/main/schemas) |
 | Build governance runtime | [Reference Runtime](aegis-runtime/) | [RFC-0002 (TBD)](rfc/RFC-0002-Governance-Runtime.md) | [Integration Examples](examples/) |
 | Deploy federation | [Federation Architecture](federation/) | [RFC-0004 (TBD)](rfc/RFC-0004-Governance-Event-Model.md) | [Ecosystem Map](aegis-core/architecture/AEGIS_Ecosystem_Map.md) |
 
@@ -203,11 +203,11 @@ The AEGIS specification is organized across five layers, from foundational princ
 | Ecosystem Map | Component interactions, data flows, deployment topologies | [Ecosystem Map](aegis-core/architecture/AEGIS_Ecosystem_Map.md) | 2 | ✅ v0.1 |
 | Threat Model | Security analysis, attack vectors, risk mitigation | [Threat Model](aegis-core/threat-model/AEGIS_ATM1_INDEX.md) | 2 | ✅ v0.1 |
 | AGP-1 Protocol | Message structures for AI-governance runtime interaction | [AGP-1 Protocol](aegis-core/protocol/AEGIS_AGP1_INDEX.md) | 3 | ✅ v0.1 |
-| AGP Schemas | Protocol message schemas and validation rules | [Schemas: AGP](aegis-core/schemas/agp/) | 3 | ✅ v0.1 |
-| Capability Schemas | Capability registry definitions and structures | [Schemas: Capability](aegis-core/schemas/capability/) | 3 | ✅ v0.1 |
-| Governance Schemas | Governance event structures and event model | [Schemas: Governance](aegis-core/schemas/governance/) | 3 | ✅ v0.1 |
-| Common Schemas | Shared data models across all schemas | [Schemas: Common](aegis-core/schemas/common/) | 3 | ✅ v0.1 |
-| Schema Examples | Example payloads demonstrating schema usage | [Schema Examples](aegis-core/schemas/examples/) | 3 | ✅ v0.1 |
+| AGP Schemas | Protocol message schemas and validation rules | [Canonical Schemas: AGP](https://github.com/aegis-initiative/aegis/tree/main/schemas/agp) | 3 | ✅ v0.1 |
+| Capability Schemas | Capability registry definitions and structures | [Canonical Schemas: Capability](https://github.com/aegis-initiative/aegis/tree/main/schemas/capability) | 3 | ✅ v0.1 |
+| Governance Schemas | Governance event structures and event model | [Canonical Schemas: Governance](https://github.com/aegis-initiative/aegis/tree/main/schemas/governance) | 3 | ✅ v0.1 |
+| Common Schemas | Shared data models across all schemas | [Canonical Schemas: Common](https://github.com/aegis-initiative/aegis/tree/main/schemas/common) | 3 | ✅ v0.1 |
+| Schema Examples | Example payloads demonstrating schema usage | Public examples should track the canonical schema set in `aegis` | 3 | ✅ v0.1 |
 | Reference Runtime | Working implementation of governance runtime components | [AEGIS Runtime](aegis-runtime/) | 4 | 🔄 In Progress |
 | Integration Examples | Pattern implementations for LangChain, CrewAI, AutoGPT, OpenAI | [Examples](examples/) | 4 | ✅ v0.1 |
 | Federation Architecture | Multi-org governance intelligence sharing and policy federation | [Federation](federation/) | 5 | ✅ v0.1 |
@@ -236,7 +236,7 @@ The AEGIS specification is organized across five layers, from foundational princ
 **Layer 3 — Protocol & Data** (Understand the formats)
 
 - How do systems communicate? → [AGP-1 Protocol](aegis-core/protocol/AEGIS_AGP1_INDEX.md)
-- What data structures are used? → [Schemas](aegis-core/schemas/)
+- What data structures are used? → [Canonical Schemas](https://github.com/aegis-initiative/aegis/tree/main/schemas)
 
 **Layer 4 — Implementation** (Build governance runtime)
 
@@ -275,18 +275,20 @@ The protocol defines message structures for:
 
 # Schema Definitions
 
-Machine-readable schemas for protocol messages and governance structures are located in the [schemas directory](aegis-core/schemas/).
+Machine-readable schemas for protocol messages and governance structures are canonically defined in the
+[`aegis` schema directory](https://github.com/aegis-initiative/aegis/tree/main/schemas). Any copies or mirrors in this
+repository should be treated as synchronized documentation artifacts rather than an independent source of truth.
 
 Key schema groups include:
 
 | Schema Group | Purpose | Location |
 |---|---|---|
-| AGP | protocol message schemas | [aegis-core/schemas/agp/](aegis-core/schemas/agp/) |
-| Capability | capability registry definitions | [aegis-core/schemas/capability/](aegis-core/schemas/capability/) |
-| Governance | governance event structures | [aegis-core/schemas/governance/](aegis-core/schemas/governance/) |
-| Common | shared data models | [aegis-core/schemas/common/](aegis-core/schemas/common/) |
+| AGP | protocol message schemas | [aegis/schemas/agp/](https://github.com/aegis-initiative/aegis/tree/main/schemas/agp) |
+| Capability | capability registry definitions | [aegis/schemas/capability/](https://github.com/aegis-initiative/aegis/tree/main/schemas/capability) |
+| Governance | governance event structures | [aegis/schemas/governance/](https://github.com/aegis-initiative/aegis/tree/main/schemas/governance) |
+| Common | shared data models | [aegis/schemas/common/](https://github.com/aegis-initiative/aegis/tree/main/schemas/common) |
 
-**Example Payloads:** [Schema Examples](aegis-core/schemas/examples/) demonstrate how the schemas are used in practice.
+**Example Payloads:** schema examples in this repository should track the canonical definitions in `aegis`.
 
 ---
 

--- a/aegis-core/schemas/README.md
+++ b/aegis-core/schemas/README.md
@@ -18,6 +18,33 @@
 
 This directory contains machine-validated schema definitions for AEGIS protocol and governance artifacts.
 
+## Mirror Sync
+
+Shared schema domains in this directory are synchronized from the canonical editable source in `../aegis/schemas/`
+using:
+
+```bash
+python scripts/sync-canonical-schemas.py
+```
+
+To check whether the mirror is out of sync without modifying files:
+
+```bash
+python scripts/sync-canonical-schemas.py --check
+```
+
+The mirror script updates only:
+
+- `agp/`
+- `capability/`
+- `common/`
+- `governance/`
+
+It intentionally does not modify:
+
+- `aiam/`
+- `examples/`
+
 ## Structure
 
 - `common/` reusable schema primitives

--- a/aegis-core/schemas/README.md
+++ b/aegis-core/schemas/README.md
@@ -8,6 +8,14 @@
 
 # AEGIS Schema Pack
 
+> **Note:** The canonical editable schemas live in
+> [`aegis/schemas/`](https://github.com/aegis-initiative/aegis/tree/main/schemas).
+> This directory is a **public mirror** with additional examples for documentation
+> purposes. Do not edit schema files here directly — changes should be made in
+> `aegis/schemas/` and synced to this directory. The `aiam/` schemas and
+> `examples/` directory are governance-specific additions that have not yet been
+> promoted upstream.
+
 This directory contains machine-validated schema definitions for AEGIS protocol and governance artifacts.
 
 ## Structure

--- a/aegis-core/schemas/agp/action_propose.schema.json
+++ b/aegis-core/schemas/agp/action_propose.schema.json
@@ -13,7 +13,8 @@
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+      "format": "date-time",
+      "pattern": "Z$"
     },
     "actor": {
       "$ref": "https://aegis-initiative.com/schemas/common/actor.schema.json"

--- a/aegis-core/schemas/agp/decision_response.schema.json
+++ b/aegis-core/schemas/agp/decision_response.schema.json
@@ -23,7 +23,8 @@
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+      "format": "date-time",
+      "pattern": "Z$"
     }
   }
 }

--- a/aegis-core/schemas/agp/escalation_request.schema.json
+++ b/aegis-core/schemas/agp/escalation_request.schema.json
@@ -23,7 +23,8 @@
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+      "format": "date-time",
+      "pattern": "Z$"
     }
   }
 }

--- a/aegis-core/schemas/agp/execution_result.schema.json
+++ b/aegis-core/schemas/agp/execution_result.schema.json
@@ -29,7 +29,8 @@
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+      "format": "date-time",
+      "pattern": "Z$"
     }
   },
   "allOf": [

--- a/aegis-core/schemas/governance/events/governance_attestation.schema.json
+++ b/aegis-core/schemas/governance/events/governance_attestation.schema.json
@@ -18,7 +18,7 @@
             "aegis_version": { "type": "string" },
             "risk_model": { "type": "string" },
             "compliance_profile": { "type": "string" },
-            "audit_timestamp": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$" },
+            "audit_timestamp": { "type": "string", "format": "date-time", "pattern": "Z$" },
             "auditor_identity": { "type": "string" }
           }
         }

--- a/aegis-core/schemas/governance/events/policy_update.schema.json
+++ b/aegis-core/schemas/governance/events/policy_update.schema.json
@@ -18,7 +18,7 @@
             "policy_id": { "type": "string" },
             "version": { "type": "string" },
             "authority": { "type": "string" },
-            "effective_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+            "effective_date": { "type": "string", "format": "date" },
             "description": { "type": "string" }
           }
         }

--- a/aegis-core/schemas/governance/events/risk_signal.schema.json
+++ b/aegis-core/schemas/governance/events/risk_signal.schema.json
@@ -16,7 +16,9 @@
           "additionalProperties": false,
           "properties": {
             "risk_category": { "type": "string" },
-            "severity": { "type": "string", "enum": ["info", "warning", "high", "critical"] },
+            "severity": {
+              "$ref": "https://aegis-initiative.com/schemas/common/risk-level.schema.json"
+            },
             "trend": { "type": "string", "enum": ["rising", "stable", "declining"] },
             "geographic_scope": { "type": "string" },
             "related_models": {

--- a/aegis-core/schemas/governance/governance_event_envelope.schema.json
+++ b/aegis-core/schemas/governance/governance_event_envelope.schema.json
@@ -12,7 +12,8 @@
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+      "format": "date-time",
+      "pattern": "Z$"
     },
     "publisher_did": {
       "type": "string",

--- a/aiam/AEGIS_AIAM1_INDEX.md
+++ b/aiam/AEGIS_AIAM1_INDEX.md
@@ -141,6 +141,13 @@ IBAC strictly generalizes prior models: an RBAC policy is an IBAC triple where t
 
 ### 5.2 Schemas
 
+> **Ownership note:** The AIAM schema set currently lives in
+> `aegis-governance/aegis-core/schemas/aiam/` as a governance-owned extension.
+> Shared cross-repository contracts for the broader AEGIS ecosystem are canonically
+> owned by [`aegis/schemas/`](https://github.com/aegis-initiative/aegis/tree/main/schemas).
+> AIAM schemas should be promoted into the canonical shared schema set only after the
+> specification stabilizes enough for downstream product and SDK consumption.
+
 | Schema | Location | Description |
 |---|---|---|
 | `common.schema.json` | `aegis-core/schemas/aiam/` | Shared type definitions: ID formats, timestamps, signatures, hashes. All other schemas `$ref` into this. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,7 +117,7 @@ This `docs/` directory contains **non-normative** design documentation.
 |----------------------------------|-------------------------------|
 | AGP-1 Protocol Specification | Architecture design documents |
 | ATM-1 Threat Model | Historical white papers |
-| JSON Schemas | Risk scoring algorithms |
+| Canonical JSON Schemas (owned by `aegis`) | Risk scoring algorithms |
 | AEGIS Constitution | Implementation guidance |
 | RFC Series | Evolution artifacts |
 
@@ -138,7 +138,7 @@ This `docs/` directory contains **non-normative** design documentation.
 **For Implementation:**
 1. Read [Governance Engine Components](architecture/GOVERNANCE_ENGINE_COMPONENTS.md)
 2. Read [End-to-End Request Flow](architecture/END_TO_END_REQUEST_FLOW.md)
-3. Study schemas in [`../aegis-core/schemas/`](../aegis-core/schemas/)
+3. Study the canonical schemas in [`aegis/schemas`](https://github.com/aegis-initiative/aegis/tree/main/schemas)
 4. Explore reference runtime in [`../aegis-runtime/`](../aegis-runtime/)
 
 ---

--- a/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
+++ b/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
@@ -139,7 +139,7 @@ Files:
 
 **Status**: Complete machine-readable schema suite
 
-Location: `aegis-core/schemas/`
+Location: canonical shared schema set in `aegis/schemas/` with synchronized documentation and examples in this repository
 
 Structure:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -187,8 +187,8 @@ See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for full guidelines.
 
 **Specifications:**
 - [AGP-1 Protocol](../aegis-core/protocol/AEGIS_AGP1_INDEX.md)
-- [Capability Schema](../aegis-core/schemas/capability/)
-- [Policy Schema](../aegis-core/schemas/governance/)
+- [Canonical Capability Schemas](https://github.com/aegis-initiative/aegis/tree/main/schemas/capability)
+- [Canonical Governance Schemas](https://github.com/aegis-initiative/aegis/tree/main/schemas/governance)
 
 **Runtime:**
 - [Reference Runtime](../aegis-runtime/)

--- a/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
+++ b/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
@@ -974,7 +974,7 @@ AGAP-1 is successfully implemented when:
 - AGP-1 Protocol — `aegis-core/protocol/AEGIS_AGP1_INDEX.md`
 - ATM-1 Threat Model — `aegis-core/threat-model/AEGIS_ATM1_INDEX.md`
 - GFN-1 Trust Model — `federation/AEGIS_GFN1_TRUST_MODEL.md`
-- Governance Attestation Schema — `aegis-core/schemas/governance/events/governance_attestation.schema.json`
+- Governance Attestation Schema — canonical shared contract in `aegis/schemas/governance/events/governance_attestation.schema.json`
 - ADR-0003 Registry Trust Model — `aegis/docs/adr/0003-registry-trust-model.md`
 - ADR-0005 Governance Federation on AT Protocol — `aegis/docs/adr/0005-governance-federation-at-protocol.md`
 - ADR-0010 Federation Monetization and Attestation Economics — `aegis/docs/adr/0010-federation-monetization-and-attestation-economics.md`

--- a/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
+++ b/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
@@ -87,7 +87,9 @@ The full AIAM-1 specification is a 12-chapter document suite located at [`aiam/`
 | Threat Model | `AEGIS_AIAM1_THREAT_MODEL.md` | Seven threat classes, ATX-1 cross-references |
 | Conformance | `AEGIS_AIAM1_CONFORMANCE.md` | 80+ requirement checklist |
 
-JSON schemas are located at `aegis-core/schemas/aiam/`:
+JSON schemas for AIAM-1 are currently located at `aegis-core/schemas/aiam/`. Shared cross-repository contracts are
+canonically owned by `aegis/schemas/`; AIAM-specific schemas in this repository should be treated as governance-owned
+extension artifacts until they are promoted into the canonical shared schema set.
 - `identity_claim.schema.json`
 - `intent_claim.schema.json`
 - `attestation_record.schema.json`

--- a/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
+++ b/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
@@ -143,6 +143,21 @@ AIAM-1 adoption is opt-in. The specification enriches AGP-1 when present but doe
 
 ---
 
+## Implementation Notes
+
+Implementation guidance is provided in the [AIAM-1 Specification Suite](../aiam/AEGIS_AIAM1_INDEX.md). Reference
+implementation is deferred to the aegis-core runtime roadmap.
+
+---
+
+## Success Criteria
+
+1. Identity claims are verifiable at the governance gateway without external round-trips.
+2. Intent-Bound Access Control decisions complete within the AGP-1 SLO budget.
+3. Principal chain delegation is auditable end-to-end through the governance event log.
+
+---
+
 ## References
 
 - [AIAM-1 Specification Suite](../aiam/AEGIS_AIAM1_INDEX.md)

--- a/scripts/sync-canonical-schemas.py
+++ b/scripts/sync-canonical-schemas.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Sync mirrored shared schemas from the canonical `aegis` repository.
+
+This script copies the shared schema domains from:
+  ../aegis/schemas/
+
+into:
+  ./aegis-core/schemas/
+
+It intentionally syncs only the shared cross-repository contract domains:
+  - agp/
+  - capability/
+  - common/
+  - governance/
+
+It does not modify:
+  - aiam/
+  - examples/
+
+Usage:
+  python scripts/sync-canonical-schemas.py
+  python scripts/sync-canonical-schemas.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MIRRORED_DIRS = ("agp", "capability", "common", "governance")
+
+
+@dataclass
+class SyncStats:
+    created: int = 0
+    updated: int = 0
+    deleted: int = 0
+    unchanged: int = 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report whether the mirror is out of sync without changing files.",
+    )
+    return parser.parse_args()
+
+
+def repo_paths() -> tuple[Path, Path]:
+    script_path = Path(__file__).resolve()
+    governance_root = script_path.parent.parent
+    workspace_root = governance_root.parent
+    canonical_root = workspace_root / "aegis" / "schemas"
+    mirror_root = governance_root / "aegis-core" / "schemas"
+    return canonical_root, mirror_root
+
+
+def ensure_roots(canonical_root: Path, mirror_root: Path) -> None:
+    if not canonical_root.exists():
+        raise SystemExit(f"Canonical schema root not found: {canonical_root}")
+    if not mirror_root.exists():
+        raise SystemExit(f"Mirror schema root not found: {mirror_root}")
+
+
+def iter_files(root: Path) -> set[Path]:
+    return {path.relative_to(root) for path in root.rglob("*") if path.is_file()}
+
+
+def sync_domain(
+    src_domain: Path,
+    dst_domain: Path,
+    *,
+    check_only: bool,
+    stats: SyncStats,
+) -> list[str]:
+    messages: list[str] = []
+    src_files = iter_files(src_domain)
+    dst_files = iter_files(dst_domain) if dst_domain.exists() else set()
+
+    for rel_path in sorted(src_files):
+        src_file = src_domain / rel_path
+        dst_file = dst_domain / rel_path
+
+        if not dst_file.exists():
+            stats.created += 1
+            messages.append(f"CREATE {dst_file}")
+            if not check_only:
+                dst_file.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src_file, dst_file)
+            continue
+
+        if filecmp.cmp(src_file, dst_file, shallow=False):
+            stats.unchanged += 1
+            continue
+
+        stats.updated += 1
+        messages.append(f"UPDATE {dst_file}")
+        if not check_only:
+            shutil.copy2(src_file, dst_file)
+
+    for rel_path in sorted(dst_files - src_files, reverse=True):
+        dst_file = dst_domain / rel_path
+        stats.deleted += 1
+        messages.append(f"DELETE {dst_file}")
+        if not check_only and dst_file.exists():
+            dst_file.unlink()
+
+    if not check_only:
+        prune_empty_dirs(dst_domain)
+
+    return messages
+
+
+def prune_empty_dirs(root: Path) -> None:
+    if not root.exists():
+        return
+    for directory in sorted((p for p in root.rglob("*") if p.is_dir()), reverse=True):
+        try:
+            next(directory.iterdir())
+        except StopIteration:
+            directory.rmdir()
+
+
+def main() -> int:
+    args = parse_args()
+    canonical_root, mirror_root = repo_paths()
+    ensure_roots(canonical_root, mirror_root)
+
+    stats = SyncStats()
+    messages: list[str] = []
+
+    for domain in MIRRORED_DIRS:
+        src_domain = canonical_root / domain
+        dst_domain = mirror_root / domain
+        if not src_domain.exists():
+            raise SystemExit(f"Missing canonical domain: {src_domain}")
+        messages.extend(
+            sync_domain(src_domain, dst_domain, check_only=args.check, stats=stats)
+        )
+
+    if messages:
+        print("\n".join(messages))
+
+    print(
+        f"created={stats.created} updated={stats.updated} "
+        f"deleted={stats.deleted} unchanged={stats.unchanged}"
+    )
+
+    if args.check and (stats.created or stats.updated or stats.deleted):
+        print("Mirror is out of sync with canonical schemas.", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a prominent notice at the top of \`aegis-core/schemas/README.md\` clarifying that:

- The canonical editable schemas live in [\`aegis/schemas/\`](https://github.com/aegis-initiative/aegis/tree/main/schemas)
- This directory is a **public mirror** with additional examples
- Do not edit schema files here directly — changes should be made upstream and synced
- The \`aiam/\` schemas and \`examples/\` directory are governance-specific additions not yet promoted upstream

Companion to [aegis#16](https://github.com/aegis-initiative/aegis/pull/16) (consolidation Phase 1A — schema ownership documentation).

## Test plan

- [ ] CI green