### PR TITLE
Add schema sync CI and include AIAM in sync

### DIFF
--- a/.github/workflows/schema-sync-check.yml
+++ b/.github/workflows/schema-sync-check.yml
@@ -1,0 +1,44 @@
+name: Schema Sync Check
+
+on:
+  pull_request:
+    paths:
+      - "aegis-core/schemas/**/*.json"
+      - "scripts/sync-canonical-schemas.py"
+      - ".github/workflows/schema-sync-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "aegis-core/schemas/**/*.json"
+      - "scripts/sync-canonical-schemas.py"
+      - ".github/workflows/schema-sync-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: schema-sync-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout aegis-governance
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: aegis-governance
+
+      - name: Checkout canonical aegis schemas
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aegis-initiative/aegis
+          path: aegis
+          sparse-checkout: schemas
+          token: ${{ secrets.AEGIS_CROSS_REPO_TOKEN }}
+
+      - name: Check mirror is in sync
+        working-directory: aegis-governance
+        run: python scripts/sync-canonical-schemas.py --check

--- a/scripts/sync-canonical-schemas.py
+++ b/scripts/sync-canonical-schemas.py
@@ -9,12 +9,12 @@ into:
 
 It intentionally syncs only the shared cross-repository contract domains:
   - agp/
+  - aiam/
   - capability/
   - common/
   - governance/
 
 It does not modify:
-  - aiam/
   - examples/
 
 Usage:
@@ -31,7 +31,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-MIRRORED_DIRS = ("agp", "capability", "common", "governance")
+MIRRORED_DIRS = ("agp", "aiam", "capability", "common", "governance")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add `schema-sync-check.yml` workflow to verify mirror stays in sync with canonical `aegis/schemas/`
- Update `sync-canonical-schemas.py` to include `aiam/` directory (now promoted to canonical)

## Test plan
- [ ] Verify `python scripts/sync-canonical-schemas.py --check` passes locally
- [ ] Confirm CI workflow triggers on schema file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)