### PR TITLE
chore: pin cache policy and add VERSION file

### DIFF
--- a/site/VERSION
+++ b/site/VERSION
@@ -1,0 +1,5 @@
+{
+  "tag": "dev",
+  "commit": "",
+  "released_at": ""
+}

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,5 +1,34 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Resolve the site version from the committed VERSION file.
+ *
+ * VERSION is a JSON file in this site directory, written by the
+ * nightly release rollup every time a 3-part release tag is cut.
+ * The Header component in @aegis-initiative/design-system reads
+ * `import.meta.env.AEGIS_VERSION`, which is populated here by
+ * mutating `process.env` before Astro/Vite loads.
+ *
+ * Note: this inline helper will be migrated to
+ * `@aegis-initiative/design-system/build`'s `readSiteVersion()`
+ * once design-system v0.4.0 is published.
+ */
+function resolveVersion() {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(resolve(here, 'VERSION'), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed.tag || 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+
+process.env.AEGIS_VERSION = resolveVersion();
 
 export default defineConfig({
   site: 'https://aegis-governance.com',

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,86 @@
+# Cloudflare Pages response headers
+# ──────────────────────────────────
+# Per-path Cache-Control policy for aegis-constitution.com.
+#
+# Why this file exists:
+#
+#   1. Repo-as-truth. Cache policy is a behavior of the site. Site
+#      behaviors belong in the repo, not in a dashboard nobody reads.
+#      Every change is versioned, reviewable, and auditable.
+#
+#   2. Drift protection. At some point prior to 2026-04-12 a zone-level
+#      setting emitted `s-maxage=604800` (7 days) on HTML responses,
+#      with no audit trail. Deleted pages were sitting at the edge for
+#      a week after they were removed from origin. This file pins the
+#      correct policy so the same regression can't happen silently.
+#
+#   3. Granularity. Zone-level settings are global. This file sets
+#      long TTLs for fingerprinted / immutable assets (fonts,
+#      /_astro/* bundles) while keeping HTML on a short leash so
+#      edits and deletions propagate quickly.
+#
+#   4. Portability. If the site ever moves off Cloudflare Pages, this
+#      file travels with it — Netlify, Vercel, and most static hosts
+#      read the same format.
+#
+# Matching rules:
+#
+#   - Cloudflare Pages applies ALL matching rules per request and
+#     merges the header sets. For conflicting headers, the more
+#     specific rule wins. So specific patterns can safely live above
+#     the catch-all `/*`.
+
+# ─────────────────────────────────────────────────────────────
+# Long-lived immutable assets — cache for a year
+# ─────────────────────────────────────────────────────────────
+
+# Astro's fingerprinted JS/CSS bundles. Filenames include a content
+# hash, so the file at a given URL never changes. Safe to cache
+# aggressively and tell the browser not to revalidate.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Self-hosted font files. Content is stable; filenames don't change
+# between deploys.
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# ─────────────────────────────────────────────────────────────
+# Moderate TTLs — stable but not strictly immutable
+# ─────────────────────────────────────────────────────────────
+
+# Brand and icon assets — change rarely, cache for a day.
+/favicon.svg
+  Cache-Control: public, max-age=86400
+
+/OG_image.png
+  Cache-Control: public, max-age=86400
+
+/OG_image.svg
+  Cache-Control: public, max-age=86400
+
+# PDFs — regenerated occasionally by the print workflow.
+/*.pdf
+  Cache-Control: public, max-age=86400
+
+# ─────────────────────────────────────────────────────────────
+# Frequently-updated assets — short TTL
+# ─────────────────────────────────────────────────────────────
+
+# Pagefind search index — rebuilt on every deploy. Short TTL so
+# search index updates (new pages, removed pages) propagate fast.
+/pagefind/*
+  Cache-Control: public, max-age=300
+
+# ─────────────────────────────────────────────────────────────
+# HTML — always revalidate
+# ─────────────────────────────────────────────────────────────
+
+# Catch-all. Applied to every path that doesn't match a more specific
+# rule above — primarily the release notes tree, the legal pages,
+# and the rendered MDX documents. `max-age=0, must-revalidate` means
+# the browser can store the response but must check with the origin
+# before serving it. This keeps edits and deletions visible within
+# seconds rather than days.
+/*
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
Propagates the `_headers` + `VERSION` pattern from aegis-constitution. See commit message for rationale.

Files are placed inside `site/` since this is a monorepo and site/ is the Astro build root.

Note: the governance spec versions (v0.1.x, v0.2.0) are separate from this VERSION file — the latter tracks the Astro site, not the specification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)