### PR TITLE
feat(ci): install release pipeline (CalVer + nightly rollup)

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,0 +1,113 @@
+name: Monthly Release
+
+on:
+  schedule:
+    - cron: '0 12 1 * *'  # Noon UTC on the 1st of each month
+  workflow_dispatch:  # Allow manual trigger for on-demand DOI minting
+
+permissions:
+  contents: write
+
+jobs:
+  monthly-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find latest tag from previous month
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual trigger — use the latest tag overall
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          else
+            # Scheduled — find latest tag from previous month
+            PREV_YEAR=$(date -d 'last month' +'%y' 2>/dev/null || date -v-1m +'%y')
+            PREV_MONTH=$(date -d 'last month' +'%-m' 2>/dev/null || date -v-1m +'%-m')
+            PREFIX="v${PREV_YEAR}.${PREV_MONTH}."
+
+            TAG=$(git tag --list "${PREFIX}*" --sort=-version:refname | head -1)
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "No tags found. Skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Found tag: $TAG"
+          fi
+
+      - name: Check if release already exists
+        if: steps.tag.outputs.skip != 'true'
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          EXISTING=$(gh release view "$TAG" --json tagName --jq '.tagName' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            echo "Release $TAG already exists. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get commits for release notes
+        if: steps.tag.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        id: commits
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+
+          # Find the previous release tag (not just any tag)
+          PREV_RELEASE=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+
+          if [ -z "$PREV_RELEASE" ]; then
+            COMMITS=$(git log --pretty=format:"- %s" "$TAG")
+          else
+            COMMITS=$(git log --pretty=format:"- %s" "${PREV_RELEASE}..${TAG}")
+          fi
+
+          # Filter out bot commits
+          FILTERED=$(echo "$COMMITS" | grep -v "^- docs: dev log entry" | grep -v "^- docs: nightly release" || echo "$COMMITS")
+
+          {
+            echo "commits<<COMMITS_EOF"
+            echo "$FILTERED"
+            echo "COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate release notes via Claude
+        if: steps.tag.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        id: notes
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RAW_COMMITS: ${{ steps.commits.outputs.commits }}
+        run: |
+          # Astro site lives in site/
+          NOTES=$(cd site && python3 scripts/generate-release-notes.py)
+          {
+            echo "notes<<NOTES_EOF"
+            echo "$NOTES"
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.tag.outputs.skip != 'true' && steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          NOTES="${{ steps.notes.outputs.notes }}"
+
+          gh release create "$TAG" \
+            --title "AEGIS™ Governance — ${TAG}" \
+            --notes "$NOTES" \
+            --latest
+
+          echo "Created release: $TAG"

--- a/.github/workflows/release-index.yml
+++ b/.github/workflows/release-index.yml
@@ -1,0 +1,128 @@
+name: Nightly Release Rollup
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # 5 AM UTC daily (1 AM ET)
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  nightly-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Determine target date
+        id: date
+        run: |
+          # For nightly runs, process yesterday. For manual, process today.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            TARGET=$(date -d 'yesterday' +'%Y-%m-%d' 2>/dev/null || date -v-1d +'%Y-%m-%d')
+          else
+            TARGET=$(date +'%Y-%m-%d')
+          fi
+          YEAR=$(date -d "$TARGET" +'%y' 2>/dev/null || date -j -f '%Y-%m-%d' "$TARGET" +'%y')
+          MONTH=$(date -d "$TARGET" +'%-m' 2>/dev/null || date -j -f '%Y-%m-%d' "$TARGET" +'%-m')
+          DAY=$(date -d "$TARGET" +'%-d' 2>/dev/null || date -j -f '%Y-%m-%d' "$TARGET" +'%-d')
+
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
+          echo "month=$MONTH" >> "$GITHUB_OUTPUT"
+          echo "day=$DAY" >> "$GITHUB_OUTPUT"
+          echo "Processing date: $TARGET"
+
+      - name: Check for daily branch
+        id: branch
+        run: |
+          YEAR="${{ steps.date.outputs.year }}"
+          MONTH="${{ steps.date.outputs.month }}"
+          DAY="${{ steps.date.outputs.day }}"
+          BRANCH="auto-releases/v${YEAR}.${MONTH}.${DAY}"
+
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "Found daily branch: $BRANCH"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No daily branch found for $BRANCH"
+          fi
+
+      - name: Merge daily branch and run rollup
+        if: steps.branch.outputs.found == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Merge the daily branch into current checkout
+          git fetch origin "$BRANCH"
+          git merge "origin/$BRANCH" --no-edit
+
+          # Run the nightly rollup for the target date. Passing year/month/day
+          # explicitly avoids a date-drift bug where the script's internal
+          # get_yesterday() helper disagreed with the workflow's notion of
+          # "yesterday" when the workflow fired after 06:00 UTC.
+          #
+          # Astro site lives in site/ — run the script from there so its
+          # internal paths resolve relative to the site root.
+          (cd site && python3 scripts/nightly-release.py \
+            --year "${{ steps.date.outputs.year }}" \
+            --month "${{ steps.date.outputs.month }}" \
+            --day "${{ steps.date.outputs.day }}")
+
+      - name: Create and merge PR
+        if: steps.branch.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          TARGET="${{ steps.date.outputs.target }}"
+          PR_BRANCH="docs/nightly-rollup-${TARGET}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage any rollup changes — release notes and VERSION file.
+          # Both live inside site/ for this repo.
+          git add site/src/content/docs/releases/ site/VERSION
+          if git diff --cached --quiet; then
+            echo "No additional rollup changes"
+          else
+            git commit -m "docs: nightly release rollup for ${TARGET}"
+          fi
+
+          # Create PR branch from current state (main + daily branch + rollup)
+          git checkout -b "$PR_BRANCH"
+          git push origin "$PR_BRANCH"
+
+          PR_URL=$(gh pr create \
+            --title "docs: release notes for ${TARGET}" \
+            --body "Daily release rollup — dev log, monthly summary, and index update for ${TARGET}." \
+            --base main \
+            --head "$PR_BRANCH")
+
+          echo "Created PR: $PR_URL"
+
+          # Auto-merge using PAT with admin bypass for branch protection
+          gh pr merge "$PR_URL" --squash --delete-branch --admin
+
+          echo "Merged and cleaned up PR"
+
+      - name: Clean up daily branch
+        if: steps.branch.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          git push origin --delete "$BRANCH" 2>/dev/null || echo "Branch already deleted"
+          echo "Cleaned up $BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip out-of-scope pushes so they don't pollute the development log:
+    #
+    # 1. Self-initiated runs (github-actions[bot]) — prevents loops where a
+    #    workflow commit triggers another workflow run.
+    # 2. Dependabot — dependency bumps are maintenance, not substantive
+    #    user-facing changes. Dependabot-style commit messages
+    #    (chore(deps...) / build(deps...)) are skipped regardless of who
+    #    merged the PR.
+    # 3. Meta rollup commits — the nightly release-index workflow creates
+    #    commits like "docs: release notes for YYYY-MM-DD", "docs: dev log
+    #    entry for vYY.M.D", and "docs: nightly release rollup for ...".
+    #    These are the workflow writing to its own output; including them
+    #    in the dev log creates a feedback loop of meaningless entries.
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.event.head_commit.message, 'chore(deps') &&
+      !startsWith(github.event.head_commit.message, 'build(deps') &&
+      !startsWith(github.event.head_commit.message, 'docs: release notes for ') &&
+      !startsWith(github.event.head_commit.message, 'docs: dev log entry for ') &&
+      !startsWith(github.event.head_commit.message, 'docs: nightly release rollup')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate development log tag
+        id: calver
+        run: |
+          # Per-push tags are always 4-part development log tags.
+          # The 3-part release tag (vYY.M.D) is reserved for the nightly
+          # rollup at the start of the next day.
+          YEAR=$(date +'%y')
+          MONTH=$(date +'%-m')
+          DAY=$(date +'%-d')
+          BASE="v${YEAR}.${MONTH}.${DAY}"
+
+          # Start at .1 and increment until we find an unused slot.
+          COUNT=1
+          TAG="${BASE}.${COUNT}"
+          while git rev-parse "$TAG" >/dev/null 2>&1; do
+            COUNT=$((COUNT + 1))
+            TAG="${BASE}.${COUNT}"
+          done
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
+          echo "month=$MONTH" >> "$GITHUB_OUTPUT"
+          echo "day=$DAY" >> "$GITHUB_OUTPUT"
+
+      - name: Get commit info
+        id: commit
+        run: |
+          echo "hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "message=$(git log -1 --pretty=format:'%s')" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.calver.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Tagged: $TAG"
+
+      - name: Append to daily dev log on auto-releases branch
+        env:
+          HASH: ${{ steps.commit.outputs.hash }}
+          MESSAGE: ${{ steps.commit.outputs.message }}
+          TAG: ${{ steps.calver.outputs.tag }}
+          YEAR: ${{ steps.calver.outputs.year }}
+          MONTH: ${{ steps.calver.outputs.month }}
+          DAY: ${{ steps.calver.outputs.day }}
+        run: |
+          BRANCH="auto-releases/v${YEAR}.${MONTH}.${DAY}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Create or switch to the daily branch
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+            git merge main --no-edit
+          else
+            git checkout -b "$BRANCH"
+          fi
+
+          # Astro site lives in site/ — run the script from there so
+          # its internal `src/content/docs/releases/...` path resolves
+          # relative to the site root. Git commands run from repo
+          # root with the site/ prefix.
+          (cd site && python3 scripts/append-dev-log.py)
+
+          FILE="site/src/content/docs/releases/${YEAR}/${MONTH}/${DAY}.md"
+          git add "$FILE"
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: dev log entry for ${TAG}"
+            git push origin "$BRANCH"
+            echo "Pushed dev log to $BRANCH"
+          fi

--- a/site/scripts/append-dev-log.py
+++ b/site/scripts/append-dev-log.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Append a commit entry to today's daily development log.
+
+Creates the daily log file if it doesn't exist.
+Appends the commit message to the Development Log section.
+
+Environment variables:
+  HASH    — short commit hash
+  MESSAGE — commit message (first line)
+  TAG     — CalVer tag
+  YEAR    — two-digit year
+  MONTH   — month number
+  DAY     — day number
+"""
+
+import os
+import re
+from datetime import datetime, timezone
+
+hash_val = os.environ["HASH"]
+message = os.environ["MESSAGE"]
+tag = os.environ["TAG"]
+year = os.environ["YEAR"]
+month = os.environ["MONTH"]
+day = os.environ["DAY"]
+
+month_name = datetime.now(timezone.utc).strftime("%B")
+day_int = int(day)
+
+file_dir = f"src/content/docs/releases/{year}/{month}"
+file_path = f"{file_dir}/{day}.md"
+os.makedirs(file_dir, exist_ok=True)
+
+dev_log_entry = f"- {message} ({hash_val})\n"
+
+if not os.path.exists(file_path):
+    # Create new daily log
+    content = f"""---
+title: "{month_name} {day_int}, 2026"
+description: "Development log for {month_name} {day_int}, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+{dev_log_entry}"""
+    with open(file_path, "w") as f:
+        f.write(content)
+    print(f"Created {file_path}")
+else:
+    with open(file_path, "r") as f:
+        content = f.read()
+
+    # Append to Development Log section
+    if "## Development Log" in content:
+        # Find the end of the Development Log heading line
+        idx = content.index("## Development Log")
+        # Find the next newline after the heading
+        nl = content.index("\n", idx)
+        # Skip any blank line after heading
+        insert_pos = nl + 1
+        if insert_pos < len(content) and content[insert_pos] == "\n":
+            insert_pos += 1
+
+        # Find end of dev log section (next ## or end of file)
+        next_section = re.search(r"\n## (?!Development Log)", content[insert_pos:])
+        if next_section:
+            append_pos = insert_pos + next_section.start()
+        else:
+            append_pos = len(content)
+
+        # Append at the end of the dev log section
+        content = content[:append_pos].rstrip("\n") + "\n" + dev_log_entry + content[append_pos:]
+    else:
+        # No dev log section yet — add one
+        content = content.rstrip("\n") + f"\n\n## Development Log\n\n{dev_log_entry}"
+
+    with open(file_path, "w") as f:
+        f.write(content)
+    print(f"Updated {file_path}")

--- a/site/scripts/generate-release-notes.py
+++ b/site/scripts/generate-release-notes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Generate release notes from git commit messages using the Claude API.
+
+Reads:
+  ANTHROPIC_API_KEY — from environment
+  RAW_COMMITS      — from environment (newline-separated commit messages)
+
+Outputs the generated notes to stdout.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+raw_commits = os.environ.get("RAW_COMMITS", "")
+
+if not api_key:
+    print("Warning: ANTHROPIC_API_KEY not set, using raw commits", file=sys.stderr)
+    print(raw_commits)
+    sys.exit(0)
+
+if not raw_commits.strip():
+    print("- No commits since last release")
+    sys.exit(0)
+
+payload = {
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "You are writing release notes for the AEGIS™ Governance "
+                "site (technical specifications — RFCs, ATX-1 taxonomy, "
+                "plugins, schemas, data portal). Convert these raw git "
+                "commit "
+                "messages into clear, professional release note entries. Keep "
+                "them concise and human-readable. Return ONLY a markdown "
+                "bulleted list, nothing else. No preamble, no explanation, "
+                "no code fences.\n\nRaw commits:\n" + raw_commits
+            ),
+        }
+    ],
+}
+
+req = urllib.request.Request(
+    "https://api.anthropic.com/v1/messages",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    },
+)
+
+try:
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+        print(data["content"][0]["text"])
+except Exception as e:
+    print(f"Warning: Claude API call failed ({e}), using raw commits", file=sys.stderr)
+    print(raw_commits)

--- a/site/scripts/nightly-release.py
+++ b/site/scripts/nightly-release.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""
+Nightly release rollup — runs at the start of the next day to seal
+the previous day's development work as a release.
+
+Steps:
+  1. Read the previous day's daily development log
+  2. Extract substantive dev log entries (filter out meta rollup
+     commits and Dependabot dependency bumps)
+  3. Rewrite the entries into publication-form release notes via the
+     Claude API — natural language, past tense, hash-stripped
+  4. Skip the release entirely if no substantive entries remain
+  5. Prepend a release recap to the top of the daily log
+  6. Add/update the release entry in the monthly release file
+  7. Add/update the entry in the release index
+  8. Write the VERSION file at the repo root
+  9. Create the 3-part release tag (vYY.M.D) pointing at the commit
+     of the last 4-part dev log tag of that day
+ 10. Push the release tag to origin
+
+Version scheme:
+  vYY.M.D.N  (4-part) — development log snapshot, created on every push
+  vYY.M.D    (3-part) — release, created here by rolling up the day's work
+
+The rollup is idempotent — existing release entries and tags are
+preserved and re-runs on the same date are safe.
+
+Environment:
+  ANTHROPIC_API_KEY — optional. If set, release summaries are rewritten
+  into public-facing prose via the Claude API. If not set, the script
+  falls back to using the raw (but filtered) dev log entries.
+
+CLI:
+  --year YY   (required) two-digit year, e.g. 26
+  --month M   (required, 1-12, no leading zero)
+  --day D     (required, 1-31, no leading zero)
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def run(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True, shell=True)
+    return result.stdout.strip()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--year", required=True, help="Two-digit year (e.g. 26)")
+    parser.add_argument("--month", required=True, help="Month (1-12, no leading zero)")
+    parser.add_argument("--day", required=True, help="Day (1-31, no leading zero)")
+    return parser.parse_args()
+
+
+def get_dev_log_tags(year, month, day):
+    """Find all 4-part development log tags for a specific date.
+
+    Returns tags of the form vYY.M.D.N sorted by N.
+    The 3-part release tag (vYY.M.D) is excluded — it's created by
+    this script, not by individual pushes.
+    """
+    prefix = f"v{year}.{month}.{day}."
+    # Use list form (no shell=True) so the glob doesn't get mangled by
+    # Windows cmd.exe when running locally.
+    result = subprocess.run(
+        ["git", "tag", "--list", "v*"],
+        capture_output=True, text=True,
+    )
+    all_tags = result.stdout.strip().split("\n")
+    pattern = re.compile(rf"^{re.escape(prefix)}\d+$")
+    tags = [t for t in all_tags if t.strip() and pattern.match(t)]
+    # Sort numerically by the trailing counter
+    tags.sort(key=lambda t: int(t.rsplit(".", 1)[-1]))
+    return tags
+
+
+def create_release_tag(release_tag, source_tag):
+    """Create the 3-part release tag pointing at source_tag's commit.
+
+    Idempotent: if release_tag already exists, log and skip.
+    Returns True if the tag was newly created.
+    """
+    existing = run(f"git rev-parse --verify --quiet refs/tags/{release_tag}")
+    if existing:
+        print(f"Release tag {release_tag} already exists — skipping creation")
+        return False
+
+    commit = run(f"git rev-list -n 1 {source_tag}")
+    if not commit:
+        print(f"Could not resolve commit for {source_tag}", file=sys.stderr)
+        return False
+
+    result = subprocess.run(
+        f"git tag {release_tag} {commit}",
+        shell=True, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"Failed to create tag {release_tag}: {result.stderr}", file=sys.stderr)
+        return False
+
+    push_result = subprocess.run(
+        f"git push origin {release_tag}",
+        shell=True, capture_output=True, text=True,
+    )
+    if push_result.returncode != 0:
+        print(f"Failed to push tag {release_tag}: {push_result.stderr}", file=sys.stderr)
+        return False
+
+    print(f"Created and pushed release tag {release_tag} → {commit[:7]}")
+    return True
+
+
+def update_version_file(release_tag, source_tag):
+    """Write the VERSION file at the repo root.
+
+    VERSION is the authoritative machine-readable record of the current
+    release. The Astro build reads it to populate the header version
+    badge. It's committed in the same rollup commit as the release
+    notes so they're always in sync.
+
+    Idempotent: writing the same tag twice is a no-op diff.
+    """
+    commit = run(f"git rev-list -n 1 {source_tag}")
+    short = commit[:7] if commit else ""
+    released_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    payload = {
+        "tag": release_tag,
+        "commit": short,
+        "released_at": released_at,
+    }
+
+    with open("VERSION", "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+    print(f"Wrote VERSION file: {release_tag} @ {short}")
+
+
+def get_builds_range(tags):
+    """Get first and last commit hashes for the day's tags."""
+    if not tags:
+        return "", ""
+    first_hash = run(f"git rev-list -1 {tags[0]}")[:7]
+    last_hash = run(f"git rev-list -1 {tags[-1]}")[:7]
+    return first_hash, last_hash
+
+
+# Commit-message patterns that indicate a commit is out of scope for
+# the public-facing release notes. Used as a safety net when reading
+# historical dev logs that were populated before the workflow-level
+# filters were in place.
+_META_PREFIXES = (
+    "docs: release notes for ",
+    "docs: dev log entry for ",
+    "docs: nightly release rollup",
+)
+_DEPS_PREFIXES = (
+    "chore(deps",
+    "build(deps",
+)
+
+
+def _is_substantive(entry):
+    """Return True if a dev log entry represents real user-facing work.
+
+    Strips the leading dash and any surrounding whitespace, then rejects
+    the entry if it matches a known meta rollup commit or a dependency
+    bump. Used to filter both new and historical dev logs.
+    """
+    body = entry.lstrip("- ").strip()
+    if any(body.startswith(p) for p in _META_PREFIXES):
+        return False
+    if any(body.startswith(p) for p in _DEPS_PREFIXES):
+        return False
+    return True
+
+
+def extract_dev_log_entries(dev_log_content):
+    """Extract substantive bullet entries from the day's development log.
+
+    Drops meta rollup commits (e.g. "docs: release notes for ...") and
+    Dependabot dependency bumps. Returns an empty list if nothing
+    substantive remains — the caller should skip release creation
+    rather than cut an empty release.
+    """
+    raw = [l.strip() for l in dev_log_content.split("\n") if l.strip().startswith("- ")]
+    return [e for e in raw if _is_substantive(e)]
+
+
+def generate_release_summary(raw_entries):
+    """Rewrite raw dev log entries into publication-form release notes.
+
+    Calls the Claude API to convert conventional-commit messages into
+    natural-language bullets suitable for a public release changelog.
+    Falls back to the raw (but filtered) entries if ANTHROPIC_API_KEY
+    is not set or the API call fails.
+    """
+    if not raw_entries:
+        return []
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return raw_entries[:20]
+
+    import json
+    import urllib.request
+
+    joined = "\n".join(raw_entries)
+
+    payload = {
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 1024,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "You are writing release notes for the AEGIS Governance "
+                    "site (technical specifications — RFCs, ATX-1 taxonomy, "
+                    "plugins, schemas, data portal). Convert these "
+                    "development "
+                    "log entries into clear, public-facing release note "
+                    "bullet points.\n\n"
+                    "Rules:\n"
+                    "- Write in natural language, past tense, user-facing.\n"
+                    "- Drop commit hashes, PR numbers, and conventional commit "
+                    "prefixes (feat:, fix:, chore:, docs:, etc.).\n"
+                    "- Group related changes together under a single bullet.\n"
+                    "- Skip internal plumbing that doesn't affect users "
+                    "(Cloudflare redeploy triggers, lockfile regenerations, "
+                    "CI config tweaks) unless they're the whole point of the "
+                    "release.\n"
+                    "- Emphasize what the reader can now do or see that they "
+                    "couldn't before.\n"
+                    "- Return ONLY a markdown bulleted list, nothing else.\n\n"
+                    "Dev log entries:\n" + joined
+                ),
+            }
+        ],
+    }
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            text = data["content"][0]["text"].strip()
+            bullets = [l.strip() for l in text.split("\n") if l.strip().startswith("- ")]
+            return bullets or raw_entries[:20]
+    except Exception as exc:
+        print(f"Warning: Claude API call failed ({exc}), using raw entries", file=sys.stderr)
+        return raw_entries[:20]
+
+
+def generate_index_summary(release_entries):
+    """Derive a one-line index summary from the release entries.
+
+    Calls the Claude API for a concise headline phrase. Falls back to
+    the first entry (hash-stripped, truncated) if the API is unavailable.
+    """
+    if not release_entries:
+        return "Updates"
+
+    def _fallback():
+        first = release_entries[0].lstrip("- ").strip()
+        first = re.sub(r"\s*\([a-f0-9]{7,}\)\s*$", "", first)
+        return first[:80]
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return _fallback()
+
+    import json
+    import urllib.request
+
+    joined = "\n".join(release_entries)
+
+    payload = {
+        "model": "claude-sonnet-4-5",
+        "max_tokens": 100,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Summarize these release notes into a single concise "
+                    "phrase (under 80 chars) for a release index. No period "
+                    "at the end. Return ONLY the phrase, no quotes.\n\n"
+                    + joined
+                ),
+            }
+        ],
+    }
+
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data["content"][0]["text"].strip().strip('"')[:80]
+    except Exception:
+        return _fallback()
+
+
+def update_daily_log(file_path, tag, builds_str, release_entries):
+    """Prepend release recap to the daily log."""
+    if not os.path.exists(file_path):
+        print(f"No daily log found at {file_path}")
+        return False
+
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    # Check if release recap already exists
+    if f"## Release / {tag}" in content:
+        print(f"Release recap already exists in {file_path}")
+        return False
+
+    # Build release recap
+    recap_lines = [f"## Release / {tag}", "", f"*Builds: {builds_str}*", ""]
+    recap_lines.extend(release_entries)
+    recap_lines.append("")
+    recap_lines.append("---")
+    recap_lines.append("")
+    recap = "\n".join(recap_lines)
+
+    # Insert after frontmatter (after second ---)
+    parts = content.split("---", 2)
+    if len(parts) >= 3:
+        content = parts[0] + "---" + parts[1] + "---\n\n" + recap + parts[2].lstrip("\n")
+    else:
+        content = content + "\n\n" + recap
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    print(f"Added release recap to {file_path}")
+    return True
+
+
+def update_monthly(year, month, tag, builds_str, release_entries, day):
+    """Add release entry to monthly file."""
+    file_path = f"src/content/docs/releases/{year}/{month}.md"
+
+    month_name = datetime.now(timezone.utc).strftime("%B")
+    year_full = datetime.now(timezone.utc).strftime("%Y")
+
+    entries_text = "\n".join(release_entries)
+    new_section = f"""## Release / {tag}
+
+*Builds: {builds_str}* — [Development Log →](/releases/{year}/{month}/{day}/)
+
+{entries_text}
+
+---
+
+"""
+
+    if not os.path.exists(file_path):
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        content = f"""---
+title: "{month_name} {year_full}"
+description: "Release notes for {month_name} {year_full}"
+template: doc
+sidebar:
+  hidden: true
+---
+
+{new_section}"""
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"Created {file_path}")
+    else:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        if f"## Release / {tag}" in content:
+            print(f"Release already exists in {file_path}")
+            return
+
+        # Insert after frontmatter
+        parts = content.split("---", 2)
+        if len(parts) >= 3:
+            content = parts[0] + "---" + parts[1] + "---\n\n" + new_section + parts[2].lstrip("\n")
+        else:
+            content = content + "\n\n" + new_section
+
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        print(f"Updated {file_path}")
+
+
+def update_index(year, month, tag, summary):
+    """Add/update entry in release index."""
+    index_path = "src/content/docs/releases/index.md"
+
+    if not os.path.exists(index_path):
+        print(f"Error: {index_path} not found", file=sys.stderr)
+        return
+
+    with open(index_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    base_tag = tag.split(".")[0] + "." + tag.split(".")[1] + "." + tag.split(".")[2]
+    anchor_tag = base_tag.replace(".", "").replace("v", "v")
+    entry_line = f"- [{base_tag}](/releases/{year}/{month}/#release--{anchor_tag}) — {summary}"
+
+    # Check if entry exists
+    entry_pattern = re.compile(rf"- \[{re.escape(base_tag)}\].*")
+    if entry_pattern.search(content):
+        content = entry_pattern.sub(entry_line, content)
+        print(f"Updated index entry for {base_tag}")
+    else:
+        year_full = datetime.now(timezone.utc).strftime("%Y")
+        month_name = datetime.now(timezone.utc).strftime("%B")
+        month_header = f"### [{month_name}](/releases/{year}/{month}/)"
+        year_header = f"## {year_full}"
+
+        if month_header in content:
+            pos = content.index(month_header) + len(month_header)
+            next_nl = content.index("\n", pos)
+            insert_pos = next_nl + 1
+            if insert_pos < len(content) and content[insert_pos] == "\n":
+                insert_pos += 1
+            content = content[:insert_pos] + entry_line + "\n" + content[insert_pos:]
+        elif year_header in content:
+            pos = content.index(year_header) + len(year_header)
+            next_nl = content.index("\n", pos)
+            insert = f"\n\n{month_header}\n\n{entry_line}\n"
+            content = content[:next_nl + 1] + insert + content[next_nl + 1:]
+        else:
+            fm_end = content.index("---", content.index("---") + 3) + 3
+            insert = f"\n\n{year_header}\n\n{month_header}\n\n{entry_line}\n"
+            content = content[:fm_end] + insert + content[fm_end:]
+
+        print(f"Added index entry for {base_tag}")
+
+    with open(index_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def main():
+    args = parse_args()
+    year = args.year
+    month = args.month
+    day = args.day
+
+    print(f"Processing releases for 20{year}-{int(month):02d}-{int(day):02d} (v{year}.{month}.{day})")
+
+    dev_tags = get_dev_log_tags(year, month, day)
+    if not dev_tags:
+        print("No development log tags found for this date. Nothing to do.")
+        sys.exit(0)
+
+    print(f"Found {len(dev_tags)} dev log tag(s): {', '.join(dev_tags)}")
+
+    # The release tag for this day
+    release_tag = f"v{year}.{month}.{day}"
+
+    # Get build hashes from the first and last dev log tags
+    first_hash, last_hash = get_builds_range(dev_tags)
+    builds_str = first_hash if first_hash == last_hash else f"{first_hash} – {last_hash}"
+
+    # Read the daily dev log
+    daily_path = f"src/content/docs/releases/{year}/{month}/{day}.md"
+    if os.path.exists(daily_path):
+        with open(daily_path, "r", encoding="utf-8") as f:
+            dev_log_content = f.read()
+    else:
+        print(f"No daily log at {daily_path}")
+        dev_log_content = ""
+
+    # Extract substantive dev log entries (meta rollup commits and
+    # Dependabot bumps are filtered out).
+    raw_entries = extract_dev_log_entries(dev_log_content)
+    print(f"Extracted {len(raw_entries)} substantive dev log entries")
+
+    if not raw_entries:
+        print("No substantive entries to release. Skipping release creation.")
+        sys.exit(0)
+
+    # Rewrite into publication-form release notes via Claude API
+    # (falls back to raw entries if no API key / API failure).
+    release_entries = generate_release_summary(raw_entries)
+    print(f"Generated {len(release_entries)} release bullets")
+
+    # Derive a one-line headline for the release index.
+    index_summary = generate_index_summary(release_entries)
+    print(f"Index summary: {index_summary}")
+
+    # Update all three release-notes files
+    update_daily_log(daily_path, release_tag, builds_str, release_entries)
+    update_monthly(year, month, release_tag, builds_str, release_entries, day)
+    update_index(year, month, release_tag, index_summary)
+
+    # Update the machine-readable VERSION file
+    update_version_file(release_tag, dev_tags[-1])
+
+    # Create the 3-part release tag pointing at the last dev log tag's commit
+    create_release_tag(release_tag, dev_tags[-1])
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/src/content/docs/releases/index.md
+++ b/site/src/content/docs/releases/index.md
@@ -1,0 +1,10 @@
+---
+title: Releases
+description: Release history for the AEGIS Governance site
+sidebar:
+  hidden: true
+---
+
+## 2026
+
+*No releases yet. The first release will be cut by the nightly rollup on the day after the first substantive push to main.*


### PR DESCRIPTION
Nested-site variant of aegis-constitution's pipeline. Completes the 5-site rollout.

## Layout choices

- Scripts at `site/scripts/`, workflows at repo root with `cd site/` before invocations (same as aegis-federation#15)
- Release content at `site/src/content/docs/releases/` (content collection, NOT `site/src/pages/releases/` like federation) — this site uses the same catch-all route + collection pattern as aegis-constitution, so no pages-based path patch is needed

## Tag namespace note

This repo also holds semver tags (`v0.1.x`, `v0.2.0`) for the governance specification. The new CalVer dev log tags (`v26.4.12.1`, etc.) coexist with those — distinct formats, no collision. The spec stays on semver; the site tracks CalVer.

## No secret setup needed

Org-level `ANTHROPIC_API_KEY` and `PAT_TOKEN` are already in place.

## After merge

1. First substantive push creates dev log tag
2. Next morning's nightly rollup cuts the `v26.4.12` release
3. VERSION file flips
4. Header on aegis-governance.com flips from `dev` to the CalVer

## Completes the batch

With this merged, all 5 AEGIS Astro sites have:
- Shared design-system Header with version badge
- VERSION file plumbing via centralized `readSiteVersion()`
- `_headers` cache policy pinned in the repo
- Release pipeline writing daily dev log entries and monthly rollups

Follow-ups (unchanged from prior discussion):
- Backport constitution's PR #78/#81 fixes to aegis-docs (has its own buggy pipeline)
- Cross-repo consistency refactor (site-in-subdirectory + content collections for everyone) — not urgent

🤖 Generated with [Claude Code](https://claude.com/claude-code)