### PR TITLE
fix(site): reconcile broken cross-document links and deploy 404 page

### DIFF
--- a/docs/outreach/2026-04-microsoft-agt-integration.md
+++ b/docs/outreach/2026-04-microsoft-agt-integration.md
@@ -1,3 +1,4 @@
+<!-- cspell:ignore VADP -->
 # Outreach: Microsoft Agent Governance Toolkit — Integration Proposal
 
 **Date sent:** Tuesday, 2026-04-14 16:49:10 (local)\

--- a/docs/outreach/2026-04-microsoft-agt-integration.md
+++ b/docs/outreach/2026-04-microsoft-agt-integration.md
@@ -1,0 +1,69 @@
+# Outreach: Microsoft Agent Governance Toolkit — Integration Proposal
+
+**Date sent:** Tuesday, 2026-04-14 16:49:10 (local)\
+**Response received:** Sunday, 2026-04-19 20:38 — from "Jack" (AGT team)\
+**From:** Kenneth Tannenbaum (AEGIS Initiative, AEGIS Operations LLC)\
+**To:** Microsoft Agent Governance Toolkit (AGT) team\
+**Channel:** Email (direct)\
+**Status:** Response received\
+**Response:** Received — content to be archived\
+**Discussion:** n/a
+
+---
+
+## Context
+
+Microsoft announced the Agent Governance Toolkit (AGT) on 2026-04-03 ([Help Net Security coverage](https://www.helpnetsecurity.com/2026/04/03/microsoft-ai-agent-governance-toolkit/)). AGT provides runtime enforcement infrastructure for agentic AI: deterministic policy evaluation, zero-trust identity, OWASP coverage.
+
+AEGIS occupies the layer upstream of runtime enforcement — the governance architecture that defines *what* policies should exist before an enforcement engine evaluates them. The two projects are structurally complementary, not competitive: AEGIS as the policy source of truth; AGT as the enforcement runtime.
+
+Outreach positions an AEGIS → AGT adapter that translates AEGIS governance profiles into AGT-compatible PolicyDocuments, so organizations adopting AGT don't have to author Cedar or Rego from scratch without a governance architecture behind it.
+
+## Summary
+
+Initial contact email to the AGT team proposing an integration conversation. Identified three AGT proposals where AEGIS governance architecture maps directly onto AGT's in-progress principal-accountability work:
+
+- **A2A trust extensions** — references VADP delegation and payment negotiation phases
+- **NEXUS**
+- **REPUTATION-GATED-AUTHORITY**
+
+Framed these as *governance terms problems, not enforcement problems* — the layer AEGIS has been building.
+
+## Email (as sent)
+
+> AGT Team —
+>
+> I've been following the Agent Governance Toolkit and wanted to reach out directly. The work is serious and fills a real gap. The enforcement infrastructure you've built — deterministic policy evaluation, zero-trust identity, OWASP coverage — is exactly what production agentic deployments need.
+>
+> I run the AEGIS Initiative, an independent research effort focused on the governance architecture layer that sits upstream of runtime enforcement. Specifically: authorization scope definition, principal delegation chains, data boundary agreements, and liability allocation between principals. The questions your toolkit presupposes have been answered — but in most deployments, they haven't been.
+>
+> Looking at your proposals folder, I notice you're already thinking about this. The A2A trust extensions proposal references VADP delegation and payment negotiation phases. The NEXUS and REPUTATION-GATED-AUTHORITY proposals are reaching toward principal accountability architecture. These are governance terms problems, not enforcement problems. That's the layer AEGIS has been building.
+>
+> I'm not writing to pitch a product. I'm writing because I think there's a genuine integration opportunity — AEGIS as the policy source of truth that feeds AGT's enforcement engine. Concretely: an adapter that translates AEGIS governance profiles into AGT-compatible PolicyDocuments, so organizations don't have to author Cedar or Rego from scratch without a governance architecture behind it.
+>
+> I'd welcome a conversation if this is of interest. I'm also happy to start with a proposal document contribution if that's a more natural entry point for your process.
+>
+> Kenneth Tannenbaum\
+> Founder, AEGIS Initiative\
+> AEGIS Operations LLC\
+> aegis-initiative.com
+>
+> Selected works:
+>
+> - [doi.org/10.5281/zenodo.19223923](https://doi.org/10.5281/zenodo.19223923) · AEGIS Core, the Python reference implementation
+> - [doi.org/10.5281/zenodo.19225675](https://doi.org/10.5281/zenodo.19225675) · ATX-1: AEGIS Threat Matrix for Agentic AI Systems
+> - [doi.org/10.5281/zenodo.19355478](https://doi.org/10.5281/zenodo.19355478) · AEGIS Core — Python Reference Implementation
+
+## Response
+
+Jack (AGT team) replied on 2026-04-19 20:38. Full response content to be archived here once pasted into this record.
+
+## Next Steps
+
+- Archive Jack's response text in this file
+- Draft reply based on response content
+- If the thread moves toward collaboration: decide between proposal-doc contribution to AGT's public repo vs. draft adapter spec in aegis-labs
+
+---
+
+> **Transparency Note:** This outreach record is archived publicly in the AEGIS repository to maintain transparency in the project's development and collaboration processes.

--- a/docs/outreach/README.md
+++ b/docs/outreach/README.md
@@ -21,6 +21,7 @@ This directory archives outreach communications to maintain transparency in the 
 | 2026-03-10 | Nathan Freestone (The Elora Taurus Project) | Architectural convergence — Elora/AEGIS execution boundary; three patterns for AEGIS spec | Active — ongoing exchange | Received — Discussions [#73](https://github.com/aegis-initiative/aegis-governance/discussions/73), [#74](https://github.com/aegis-initiative/aegis-governance/discussions/74), [#75](https://github.com/aegis-initiative/aegis-governance/discussions/75) |
 | 2026-03-13 | William Torgbi Agbemabiese | Constitutional Autonomy + AEGIS multi-layer governance | Initial outreach sent | Pending |
 | 2026-03-14 | Mattijs Moens (Sovereign Shield) | Trust decay determinism objection — GFN-1 §3.8 / RFC-0004 | Response received | Received — Discussion [#72](https://github.com/aegis-initiative/aegis-governance/discussions/72) |
+| 2026-04-14 | Microsoft Agent Governance Toolkit (AGT) team (Jack) | Integration proposal — AEGIS as policy source of truth upstream of AGT enforcement runtime | Response received | Received — 2026-04-19 |
 
 ---
 

--- a/docs/position-papers/nist/README.md
+++ b/docs/position-papers/nist/README.md
@@ -25,6 +25,22 @@ This directory contains AEGIS™ responses to:
 - **Status**: Submitted for Public Comment and Community Review
 - **Submission Type**: Unsolicited Position Paper
 
+#### Priority-date evidence chain
+
+Independently verifiable timestamps establishing the authorship and submission date of this position paper:
+
+| Artifact | Timestamp (ET) | Verification |
+|---|---|---|
+| First commit of paper (`bf7117d`) | 2026-03-07 11:14:21 | `git log` in this repo |
+| "Publish official NIST AI RMF position statement" (`58f31e7`) | 2026-03-07 12:01:25 | `git log` in this repo |
+| Final pre-submission refinement (`ca36690`) | 2026-03-07 12:13:52 | `git log` in this repo |
+| Public announcement on LinkedIn | 2026-03-07 12:30:34 | [Post](https://www.linkedin.com/feed/update/urn:li:activity:7436100999439732736/) — activity ID `7436100999439732736`; timestamp is Snowflake-encoded in the ID (`id >> 22` = ms since Unix epoch) |
+| Marked final in repo (`e2b4df0`) | 2026-03-13 08:05:28 | `git log` in this repo |
+
+The LinkedIn activity ID is self-authenticating: the millisecond-precision publication timestamp is cryptographically embedded in the URL and cannot be backdated.
+
+For comparison, Anthropic's response to NIST RFI NIST-2025-0035 ("Security Considerations for Artificial Intelligence Agents") is dated **2026-03-09** — 48 hours after the AEGIS submission and the LinkedIn announcement of it.
+
 ## Notes
 
 - The Markdown file is for reference only. The PDF is the authoritative version as submitted to NIST.

--- a/site/src/content/docs/architecture/ai-kernel-model.md
+++ b/site/src/content/docs/architecture/ai-kernel-model.md
@@ -170,9 +170,9 @@ systems remain bounded, accountable, and operationally safe.
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/architecture/capability-flow.md
+++ b/site/src/content/docs/architecture/capability-flow.md
@@ -125,6 +125,6 @@ The flow is valid only if:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/capability-model.md
+++ b/site/src/content/docs/architecture/capability-model.md
@@ -131,6 +131,6 @@ Bulk grant and revoke operations must preserve audit history.
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/decision-algorithm.md
+++ b/site/src/content/docs/architecture/decision-algorithm.md
@@ -213,6 +213,6 @@ Requests with risk_score ≥ 61 are escalated to:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/engine-components.md
+++ b/site/src/content/docs/architecture/engine-components.md
@@ -246,6 +246,6 @@ All component access is synchronized through DecisionEngine.authorize()[^1]
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/engine-spec.md
+++ b/site/src/content/docs/architecture/engine-spec.md
@@ -209,6 +209,6 @@ risk evaluation within defined trust boundaries.
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/index.md
+++ b/site/src/content/docs/architecture/index.md
@@ -121,9 +121,9 @@ to produce safe, auditable, and operationally robust AI behavior.
 
 ### References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/architecture/policy-language.md
+++ b/site/src/content/docs/architecture/policy-language.md
@@ -255,6 +255,6 @@ When multiple policies match:
 
 ## References
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](../../REFERENCES.md).
+[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/policy-matching.md
+++ b/site/src/content/docs/architecture/policy-matching.md
@@ -374,4 +374,4 @@ audit_id: audit_xyz789
 
 ### References
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/principles.md
+++ b/site/src/content/docs/architecture/principles.md
@@ -137,16 +137,16 @@ Each release SHOULD include a principle compliance checklist proving:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^13]: National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Jan. 2023, doi: 10.6028/NIST.AI.100-1. See [REFERENCES.md](../../REFERENCES.md).
+[^13]: National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Jan. 2023, doi: 10.6028/NIST.AI.100-1. See [REFERENCES.md](/references/).
 
-[^15]: European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, 12 Jul. 2024. See [REFERENCES.md](../../REFERENCES.md).
+[^15]: European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, 12 Jul. 2024. See [REFERENCES.md](/references/).
 
-[^16]: International Organization for Standardization and International Electrotechnical Commission, "Information technology — Artificial intelligence — Management system," ISO/IEC 42001:2023(E), Geneva, Switzerland, Dec. 2023. See [REFERENCES.md](../../REFERENCES.md).
+[^16]: International Organization for Standardization and International Electrotechnical Commission, "Information technology — Artificial intelligence — Management system," ISO/IEC 42001:2023(E), Geneva, Switzerland, Dec. 2023. See [REFERENCES.md](/references/).
 
-[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).
 
-[^22]: J. H. Saltzer and M. D. Schroeder, "The protection of information in computer systems," *Proc. IEEE*, vol. 63, no. 9, pp. 1278–1308, Sep. 1975, doi: 10.1109/PROC.1975.9939. See [REFERENCES.md](../../REFERENCES.md).
+[^22]: J. H. Saltzer and M. D. Schroeder, "The protection of information in computer systems," *Proc. IEEE*, vol. 63, no. 9, pp. 1278–1308, Sep. 1975, doi: 10.1109/PROC.1975.9939. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/reference-monitor.md
+++ b/site/src/content/docs/architecture/reference-monitor.md
@@ -110,6 +110,6 @@ Using a reference monitor model in AEGIS provides:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/reference.md
+++ b/site/src/content/docs/architecture/reference.md
@@ -23,7 +23,7 @@ This design ensures that AI systems cannot directly execute operational actions 
 
 ---
 
-> **Architectural Layer Enforcement**: AEGIS operates at the architectural layer, enforcing policy at the execution boundary between AI agents and infrastructure. Unlike model-internal approaches (Constitutional AI, RLHF, fine-tuning), AEGIS is model-agnostic, deterministic, and federated. See [System Overview](../overview/AEGIS_System_Overview.md#architectural-positioning) for detailed positioning.
+> **Architectural Layer Enforcement**: AEGIS operates at the architectural layer, enforcing policy at the execution boundary between AI agents and infrastructure. Unlike model-internal approaches (Constitutional AI, RLHF, fine-tuning), AEGIS is model-agnostic, deterministic, and federated. See [System Overview](/foundation/overview/#architectural-positioning) for detailed positioning.
 
 ---
 
@@ -955,15 +955,15 @@ Together these documents define the complete AEGIS™ governance architecture.
 
 ### References
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).
 
-[^7]: A. Baird, A. Panda, H. Pearce, S. Pinisetty, and P. Roop, "Scalable Security Enforcement for Cyber Physical Systems," *IEEE Access*, vol. 12, pp. 14385–14410, 2024, doi: 10.1109/ACCESS.2024.3357714. See [REFERENCES.md](../../REFERENCES.md).
+[^7]: A. Baird, A. Panda, H. Pearce, S. Pinisetty, and P. Roop, "Scalable Security Enforcement for Cyber Physical Systems," *IEEE Access*, vol. 12, pp. 14385–14410, 2024, doi: 10.1109/ACCESS.2024.3357714. See [REFERENCES.md](/references/).
 
-[^8]: K. Arunachalam, A. Kayyidavazhiyil, and P. Santikellur, "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems," *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*, 2026, doi: 10.1109/CCNC65079.2026.11366307. See [REFERENCES.md](../../REFERENCES.md).
+[^8]: K. Arunachalam, A. Kayyidavazhiyil, and P. Santikellur, "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems," *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*, 2026, doi: 10.1109/CCNC65079.2026.11366307. See [REFERENCES.md](/references/).
 
-[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](../../REFERENCES.md).
+[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](/references/).
 
-[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/architecture/risk-algorithm.md
+++ b/site/src/content/docs/architecture/risk-algorithm.md
@@ -260,6 +260,6 @@ Regularly audit risk scores for bias across:
 
 ## References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).
 
-[^30]: Z. Engin and N. Hand, "Toward Adaptive Categories: Dimensional Governance for Agentic AI," arXiv:2505.11579v2, 2025. [Online]. Available: <https://arxiv.org/pdf/2505.11579>. See [REFERENCES.md](../../REFERENCES.md).
+[^30]: Z. Engin and N. Hand, "Toward Adaptive Categories: Dimensional Governance for Agentic AI," arXiv:2505.11579v2, 2025. [Online]. Available: <https://arxiv.org/pdf/2505.11579>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/risk-model.md
+++ b/site/src/content/docs/architecture/risk-model.md
@@ -110,4 +110,4 @@ The risk model is considered healthy when:
 
 ## References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/security-assumptions.md
+++ b/site/src/content/docs/architecture/security-assumptions.md
@@ -166,4 +166,4 @@ This document MUST be reviewed:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/system-stack.md
+++ b/site/src/content/docs/architecture/system-stack.md
@@ -105,8 +105,8 @@ and only constrained execution paths can invoke capability.[^1][^2]
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/architecture/trust-boundaries.md
+++ b/site/src/content/docs/architecture/trust-boundaries.md
@@ -161,12 +161,12 @@ Boundary verification should prove:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](../../REFERENCES.md).
+[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](/references/).
 
-[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).
 
-[^22]: J. H. Saltzer and M. D. Schroeder, "The protection of information in computer systems," *Proc. IEEE*, vol. 63, no. 9, pp. 1278–1308, Sep. 1975, doi: 10.1109/PROC.1975.9939. See [REFERENCES.md](../../REFERENCES.md).
+[^22]: J. H. Saltzer and M. D. Schroeder, "The protection of information in computer systems," *Proc. IEEE*, vol. 63, no. 9, pp. 1278–1308, Sep. 1975, doi: 10.1109/PROC.1975.9939. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/federation/index.md
+++ b/site/src/content/docs/federation/index.md
@@ -272,6 +272,6 @@ By combining federated architecture, verifiable identities,[^17] governance sign
 
 ## References
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/federation/node-architecture.md
+++ b/site/src/content/docs/federation/node-architecture.md
@@ -5,7 +5,7 @@ description: "GFN-1 node reference architecture — federation participant desig
 
 # AEGIS GFN-1 Node Reference Architecture & Deployment
 
-**Document**: GFN-1/Nodes (AEGIS_GFN1_NODE_REFERENCE_ARCHITECTURE.md)\
+**Document**: GFN-1/Nodes (/federation/node-architecture/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Federation Network\
 **Last Updated**: March 6, 2026
@@ -1362,17 +1362,17 @@ Detailed configuration schema document available in accompanying `AEGIS_NODE_CON
 
 ## Related Documents
 
-- [AEGIS_GFN1_TRUST_MODEL.md](./AEGIS_GFN1_TRUST_MODEL.md) - Trust scoring and bootstrap mechanisms
-- [AEGIS_Governance_Event_Model.md](../rfc/RFC-0004-Governance-Event-Model.md) - Event envelope schemas
-- [AEGIS_AGP1_INDEX.md](../aegis-core/protocol/AEGIS_AGP1_INDEX.md) - Wire protocol specification
+- [AEGIS_GFN1_TRUST_MODEL.md](/federation/trust-model/) - Trust scoring and bootstrap mechanisms
+- [AEGIS_Governance_Event_Model.md](/rfc/0004/) - Event envelope schemas
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Wire protocol specification
 - [AEGIS Constitution](https://aegis-constitution.com) - Governance principles
 
 ---
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/federation/schema.md
+++ b/site/src/content/docs/federation/schema.md
@@ -5,7 +5,7 @@ description: "GFN-1 schema — AT Protocol lexicons for governance federation"
 
 # AEGIS GFN-1 Event Schemas & Data Definitions
 
-**Document**: GFN-1/Schema (AEGIS_GFN1_SCHEMA.md)\
+**Document**: GFN-1/Schema (/federation/schema/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Federation Network\
 **Last Updated**: March 6, 2026

--- a/site/src/content/docs/federation/trust-model.md
+++ b/site/src/content/docs/federation/trust-model.md
@@ -5,7 +5,7 @@ description: "GFN-1 trust model — federated publisher reputation scoring"
 
 # AEGIS GFN-1 Trust Model & Federated Reputation
 
-**Document**: GFN-1/Trust (AEGIS_GFN1_TRUST_MODEL.md)\
+**Document**: GFN-1/Trust (/federation/trust-model/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Federation Network\
 **Last Updated**: March 15, 2026
@@ -902,8 +902,8 @@ Nodes MUST implement safe defaults:
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: https://doi.org/10.6028/NIST.SP.800-207. See [REFERENCES.md](../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: https://doi.org/10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/foundation/overview.md
+++ b/site/src/content/docs/foundation/overview.md
@@ -486,25 +486,25 @@ Ready to explore AEGIS governance? Follow this learning path:
 
 ### Step 1: Understand the Why
 
-- **Read:** [The AEGIS Manifesto](../manifesto/AEGIS_Manifesto.md) — Learn why architectural governance matters
+- **Read:** [The AEGIS Manifesto](/foundation/) — Learn why architectural governance matters
 - **Review:** The "Why AEGIS?" section above — Compare governance approaches
 - **Key Takeaway:** Governance must be architectural, not aspirational
 
 ### Step 2: Learn the Architecture
 
-- **Read:** [AEGIS Reference Architecture](../architecture/AEGIS_Reference_Architecture.md) — Understand core components
-- **Review:** [Ecosystem Map](../architecture/AEGIS_Ecosystem_Map.md) — See how components interact
+- **Read:** [AEGIS Reference Architecture](/architecture/reference/) — Understand core components
+- **Review:** [Ecosystem Map](/architecture/ecosystem-map/) — See how components interact
 - **Key Takeaway:** Governance sits between AI reasoning and execution
 
 ### Step 3: Understand Governance Principles
 
-- **Read:** [AEGIS Constitution](../constitution/AEGIS_Constitution.md) — Learn the 8 foundational articles
+- **Read:** [AEGIS Constitution](https://aegis-constitution.com/) — Learn the 8 foundational articles
 - **Review:** Constitutional compliance mechanisms and enforcement
 - **Key Takeaway:** Governance is enforced by architecture, not model behavior
 
 ### Step 4: Assess Adoption Level
 
-- **Read:** [AEGIS FAQ - Adoption Model](../faq/AEGIS_FAQ.md#aegis-adoption-model) — Understand the 3-level maturity framework
+- **Read:** [AEGIS FAQ - Adoption Model](/foundation/faq/#aegis-adoption-model) — Understand the 3-level maturity framework
 - **Level 1:** Gateway (capability boundaries, action governance)
 - **Level 2:** Full Runtime (policies, risk evaluation, audit)
 - **Level 3:** Federation (distributed intelligence, collective defense)
@@ -512,13 +512,13 @@ Ready to explore AEGIS governance? Follow this learning path:
 
 ### Step 5: Review Threat Model
 
-- **Read:** [AEGIS Threat Model](../threat-model/AEGIS_ATM1_INDEX.md) — Understand attack vectors
+- **Read:** [AEGIS Threat Model](/threat-model/) — Understand attack vectors
 - **Review:** STRIDE-based threat analysis and mitigation strategies
 - **Key Takeaway:** Governance must defend against adversarial behavior
 
 ### Step 6: Explore Implementation
 
-- **Read:** [AEGIS FAQ](../faq/AEGIS_FAQ.md) — Practical integration questions
+- **Read:** [AEGIS FAQ](/foundation/faq/) — Practical integration questions
 - **Review:** Integration examples (LangChain, CrewAI, AutoGPT)
 - **Study:** "Hello AEGIS" code examples
 - **Key Takeaway:** AEGIS integrates with existing agent frameworks
@@ -542,12 +542,12 @@ Ready to explore AEGIS governance? Follow this learning path:
 
 | If you want to... | Start here |
 |-------------------|------------|
-| Understand the vision | [Manifesto](../manifesto/AEGIS_Manifesto.md) |
-| Learn the architecture | [Reference Architecture](../architecture/AEGIS_Reference_Architecture.md) |
-| See integration examples | [FAQ](../faq/AEGIS_FAQ.md) |
-| Understand principles | [Constitution](../constitution/AEGIS_Constitution.md) |
-| Assess security | [Threat Model](../threat-model/AEGIS_ATM1_INDEX.md) |
-| Plan adoption | [FAQ - Adoption Model](../faq/AEGIS_FAQ.md#aegis-adoption-model) |
+| Understand the vision | [Manifesto](/foundation/) |
+| Learn the architecture | [Reference Architecture](/architecture/reference/) |
+| See integration examples | [FAQ](/foundation/faq/) |
+| Understand principles | [Constitution](https://aegis-constitution.com/) |
+| Assess security | [Threat Model](/threat-model/) |
+| Plan adoption | [FAQ - Adoption Model](/foundation/faq/#aegis-adoption-model) |
 | Join the community | [GitHub Discussions](https://github.com/aegis-initiative/aegis-governance/discussions) |
 
 ---
@@ -556,31 +556,31 @@ Ready to explore AEGIS governance? Follow this learning path:
 
 ### References
 
-[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Web Service Message Contracts with Data," *IEEE Transactions on Services Computing*, vol. 5, no. 2, pp. 192–206, April–June 2012, doi: 10.1109/TSC.2011.10. See [REFERENCES.md](../../REFERENCES.md).
+[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Web Service Message Contracts with Data," *IEEE Transactions on Services Computing*, vol. 5, no. 2, pp. 192–206, April–June 2012, doi: 10.1109/TSC.2011.10. See [REFERENCES.md](/references/).
 
-[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](../../REFERENCES.md).
+[^4]: S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13. See [REFERENCES.md](/references/).
 
-[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](../../REFERENCES.md).
+[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](/references/).
 
-[^6]: S. Majumdar et al., "ProSAS: Proactive Security Auditing System for Clouds," *IEEE Transactions on Dependable and Secure Computing*, vol. 19, no. 4, pp. 2517–2534, July–Aug. 2022, doi: 10.1109/TDSC.2021.3062204. See [REFERENCES.md](../../REFERENCES.md).
+[^6]: S. Majumdar et al., "ProSAS: Proactive Security Auditing System for Clouds," *IEEE Transactions on Dependable and Secure Computing*, vol. 19, no. 4, pp. 2517–2534, July–Aug. 2022, doi: 10.1109/TDSC.2021.3062204. See [REFERENCES.md](/references/).
 
-[^8]: K. Arunachalam, A. Kayyidavazhiyil, and P. Santikellur, "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems," *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*, 2026, doi: 10.1109/CCNC65079.2026.11366307. See [REFERENCES.md](../../REFERENCES.md).
+[^8]: K. Arunachalam, A. Kayyidavazhiyil, and P. Santikellur, "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems," *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*, 2026, doi: 10.1109/CCNC65079.2026.11366307. See [REFERENCES.md](/references/).
 
-[^9]: P. Christiano, J. Leike, T. B. Brown, M. Martic, S. Legg, and D. Amodei, "Deep Reinforcement Learning from Human Preferences," in *Advances in Neural Information Processing Systems (NeurIPS)*, 2017, arXiv:1706.03741. See [REFERENCES.md](../../REFERENCES.md).
+[^9]: P. Christiano, J. Leike, T. B. Brown, M. Martic, S. Legg, and D. Amodei, "Deep Reinforcement Learning from Human Preferences," in *Advances in Neural Information Processing Systems (NeurIPS)*, 2017, arXiv:1706.03741. See [REFERENCES.md](/references/).
 
-[^10]: Y. Bai et al., "Constitutional AI: Harmlessness from AI Feedback," arXiv:2212.08073, Dec. 2022. [Online]. Available: <https://arxiv.org/abs/2212.08073>. See [REFERENCES.md](../../REFERENCES.md).
+[^10]: Y. Bai et al., "Constitutional AI: Harmlessness from AI Feedback," arXiv:2212.08073, Dec. 2022. [Online]. Available: <https://arxiv.org/abs/2212.08073>. See [REFERENCES.md](/references/).
 
-[^13]: National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Jan. 2023, doi: 10.6028/NIST.AI.100-1. See [REFERENCES.md](../../REFERENCES.md).
+[^13]: National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Jan. 2023, doi: 10.6028/NIST.AI.100-1. See [REFERENCES.md](/references/).
 
-[^15]: European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, 12 Jul. 2024. See [REFERENCES.md](../../REFERENCES.md).
+[^15]: European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, 12 Jul. 2024. See [REFERENCES.md](/references/).
 
-[^11]: W. T. Agbemabiese, "Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence," *IEEE Access*, vol. 14, pp. 11385–11402, 2026, doi: 10.1109/ACCESS.2026.3654907. See [REFERENCES.md](../../REFERENCES.md).
+[^11]: W. T. Agbemabiese, "Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence," *IEEE Access*, vol. 14, pp. 11385–11402, 2026, doi: 10.1109/ACCESS.2026.3654907. See [REFERENCES.md](/references/).
 
-[^12]: N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026. [Online]. Available: <https://arxiv.org/abs/2602.20021>. See [REFERENCES.md](../../REFERENCES.md).
+[^12]: N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026. [Online]. Available: <https://arxiv.org/abs/2602.20021>. See [REFERENCES.md](/references/).
 
-[^28]: Various authors, "A survey of agentic AI and cybersecurity: Challenges, opportunities and use-case prototypes," arXiv:2601.05293v1, 2026. [Online]. Available: <https://arxiv.org/abs/2601.05293>. See [REFERENCES.md](../../REFERENCES.md).
+[^28]: Various authors, "A survey of agentic AI and cybersecurity: Challenges, opportunities and use-case prototypes," arXiv:2601.05293v1, 2026. [Online]. Available: <https://arxiv.org/abs/2601.05293>. See [REFERENCES.md](/references/).
 
-[^29]: R. Chan et al., "The 2025 AI Agent Index," arXiv:2602.17753v1, 2025. [Online]. Available: <https://arxiv.org/abs/2602.17753>. See [REFERENCES.md](../../REFERENCES.md).
+[^29]: R. Chan et al., "The 2025 AI Agent Index," arXiv:2602.17753v1, 2025. [Online]. Available: <https://arxiv.org/abs/2602.17753>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/identity/attestation.md
+++ b/site/src/content/docs/identity/attestation.md
@@ -5,7 +5,7 @@ description: "AIAM-1 attestation — action-level governance decision proof"
 
 # AEGIS AIAM-1: Attestation and Audit
 
-**Document**: AIAM-1/Attestation (AEGIS_AIAM1_ATTESTATION.md)\
+**Document**: AIAM-1/Attestation (/identity/attestation/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026

--- a/site/src/content/docs/identity/authority.md
+++ b/site/src/content/docs/identity/authority.md
@@ -5,7 +5,7 @@ description: "AIAM-1 authority model — IBAC authorization framework"
 
 # AEGIS AIAM-1: Authority Binding (IBAC)
 
-**Document**: AIAM-1/Authority (AEGIS_AIAM1_AUTHORITY.md)\
+**Document**: AIAM-1/Authority (/identity/authority/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -47,9 +47,9 @@ Authorization Decision = f(Identity, Action, Intent Context)
 
 Where:
 
-- **Identity** is an AIAM-1 composite identity claim (see [IDENTITY](AEGIS_AIAM1_IDENTITY.md)): model provenance, orchestration layer, goal context, and principal.
+- **Identity** is an AIAM-1 composite identity claim (see [IDENTITY](/identity/identity/)): model provenance, orchestration layer, goal context, and principal.
 - **Action** is a structured action proposal: capability identifier, action type, target resource, and parameters.
-- **Intent Context** is an AIAM-1 intent claim (see [INTENT](AEGIS_AIAM1_INTENT.md)): goal reference, reasoning summary, expected outcome, and dependency chain.
+- **Intent Context** is an AIAM-1 intent claim (see [INTENT](/identity/intent/)): goal reference, reasoning summary, expected outcome, and dependency chain.
 
 An authorization decision based on identity and action alone — without intent context — is not IBAC. It may be valid access control, but it is not conformant with AIAM-1.
 
@@ -382,7 +382,7 @@ An incomplete policy set may fail to deny actions that should be denied. The def
 #### 8.2 Intent Pattern Evasion
 
 An attacker who understands the intent patterns in IBAC policies could craft intent claims that match authorizing patterns while pursuing malicious goals. Mitigations:
-- Intent spoofing detection mechanisms (see [INTENT §5](AEGIS_AIAM1_INTENT.md#5-intent-spoofing-detection)).
+- Intent spoofing detection mechanisms (see [INTENT §5](/identity/intent/#5-intent-spoofing-detection)).
 - Action-intent coherence checks that verify parameters are consistent with declared intent.
 - Outcome verification that compares actual results against declared expected outcomes.
 

--- a/site/src/content/docs/identity/capabilities.md
+++ b/site/src/content/docs/identity/capabilities.md
@@ -5,7 +5,7 @@ description: "AIAM-1 capability binding — identity-scoped capability grants"
 
 # AEGIS AIAM-1: Capability Scoping
 
-**Document**: AIAM-1/Capabilities (AEGIS_AIAM1_CAPABILITIES.md)\
+**Document**: AIAM-1/Capabilities (/identity/capabilities/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -72,7 +72,7 @@ AGP-1 and RFC-0003 define a capability registry with hierarchical dotted identif
 
 ### 3.2 Composition Governance
 
-**AIAM1-CAP-010.** A conformant implementation MUST treat capability composition as a governed operation. Capability composition occurs when an agent executes a sequence of individually authorized capabilities that together produce an effect not achievable by any single capability in the sequence. Composition governance applies to sequences of capabilities and to combinations of delegated and independent authority (see [AUTHORITY §3.4, AIAM1-AUTH-024](AEGIS_AIAM1_AUTHORITY.md#34-policy-lifecycle)).
+**AIAM1-CAP-010.** A conformant implementation MUST treat capability composition as a governed operation. Capability composition occurs when an agent executes a sequence of individually authorized capabilities that together produce an effect not achievable by any single capability in the sequence. Composition governance applies to sequences of capabilities and to combinations of delegated and independent authority (see [AUTHORITY §3.4, AIAM1-AUTH-024](/identity/authority/#34-policy-lifecycle)).
 
 **AIAM1-CAP-011.** Capability authorization MUST NOT be closed under transitivity. An agent authorized to perform capability A and capability B is not, by default, authorized to perform the composition A-then-B. The composition MUST be explicitly authorized as a distinct action or evaluated against IBAC policies as a composed action.
 

--- a/site/src/content/docs/identity/conformance.md
+++ b/site/src/content/docs/identity/conformance.md
@@ -5,7 +5,7 @@ description: "AIAM-1 conformance — compliance levels and validation criteria"
 
 # AEGIS AIAM-1: Conformance
 
-**Document**: AIAM-1/Conformance (AEGIS_AIAM1_CONFORMANCE.md)\
+**Document**: AIAM-1/Conformance (/identity/conformance/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -37,7 +37,7 @@ These are not specified in v0.1.
 
 The following checklist enumerates all MUST and MUST NOT requirements from the AIAM-1 specification suite. A conformant implementation satisfies all items marked MUST and violates no items marked MUST NOT.
 
-### 3.1 Identity (AEGIS_AIAM1_IDENTITY.md)
+### 3.1 Identity (/identity/identity/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -59,7 +59,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-ID-053 | Revocation within propagation latency guarantee | MUST |
 | AIAM1-ID-054 | Identity lifecycle events produce attestation records | MUST |
 
-### 3.2 Intent (AEGIS_AIAM1_INTENT.md)
+### 3.2 Intent (/identity/intent/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -76,7 +76,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-INT-031 | Sub-agent intent independently valid against sub-agent's own identity | MUST |
 | AIAM1-INT-050 | Intent claims not reusable across action proposals; reject reused action_ref | MUST NOT reuse |
 
-### 3.3 Authority / IBAC (AEGIS_AIAM1_AUTHORITY.md)
+### 3.3 Authority / IBAC (/identity/authority/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -94,7 +94,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-AUTH-024 | Mixed delegated + independent authority evaluated as composed action (CAP-010) | MUST |
 | AIAM1-AUTH-030 | External trust scores do not override IBAC decisions | MUST NOT |
 
-### 3.4 Capabilities (AEGIS_AIAM1_CAPABILITIES.md)
+### 3.4 Capabilities (/identity/capabilities/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -109,7 +109,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-CAP-021 | Constraint violation → DENY (not advisory) | MUST |
 | AIAM1-CAP-030 | Composition evaluation over at least the current session | MUST |
 
-### 3.5 Delegation (AEGIS_AIAM1_DELEGATION.md)
+### 3.5 Delegation (/identity/delegation/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -126,7 +126,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-DEL-024 | Revocation cascade mandatory by default for downstream delegated authority | MUST |
 | AIAM1-DEL-025 | Cascade opt-out (`cascade_on_revocation: false`) permitted with attestation, justification, and policy governance | MAY (with MUST conditions) |
 
-### 3.6 Sessions (AEGIS_AIAM1_SESSIONS.md)
+### 3.6 Sessions (/identity/sessions/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -141,7 +141,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-SES-020 | No silent session escalation | MUST NOT |
 | AIAM1-SES-021 | Exceeding session boundaries requires new session with new authorization | MUST |
 
-### 3.7 Attestation (AEGIS_AIAM1_ATTESTATION.md)
+### 3.7 Attestation (/identity/attestation/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -161,7 +161,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-ATT-032 | Attestation is primary accountability surface; no substitution with agent logs | MUST NOT substitute |
 | AIAM1-ATT-040 | Attestation failure → DENY action (fail-closed) | MUST |
 
-### 3.8 Revocation (AEGIS_AIAM1_REVOCATION.md)
+### 3.8 Revocation (/identity/revocation/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -180,7 +180,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-REV-032 | Independent grants unaffected by upstream revocation | MUST NOT revoke |
 | AIAM1-REV-033 | Cascade propagates to full chain depth | MUST |
 
-### 3.9 Interoperability (AEGIS_AIAM1_INTEROPERABILITY.md)
+### 3.9 Interoperability (/identity/interoperability/)
 
 | ID | Requirement | Type |
 |---|---|---|
@@ -193,7 +193,7 @@ The following checklist enumerates all MUST and MUST NOT requirements from the A
 | AIAM1-IOP-050 | Interop mappings do not compromise AIAM-1 primitive integrity | MUST NOT compromise |
 | AIAM1-IOP-051 | Governance gateway is authoritative for IBAC; interop protocols are complementary | MUST |
 
-### 3.10 Threat Model (AEGIS_AIAM1_THREAT_MODEL.md)
+### 3.10 Threat Model (/identity/threat-model/)
 
 | ID | Requirement | Type |
 |---|---|---|

--- a/site/src/content/docs/identity/delegation.md
+++ b/site/src/content/docs/identity/delegation.md
@@ -5,7 +5,7 @@ description: "AIAM-1 delegation — authority transfer and chain validation"
 
 # AEGIS AIAM-1: Delegation and Principal Chains
 
-**Document**: AIAM-1/Delegation (AEGIS_AIAM1_DELEGATION.md)\
+**Document**: AIAM-1/Delegation (/identity/delegation/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -307,7 +307,7 @@ An agent might rapidly instantiate many sub-agents to overwhelm governance evalu
 
 If a delegating agent is revoked or terminated, its sub-agents may continue operating with delegated authority from a now-invalid source. Mitigations:
 - Delegation grants MUST have explicit expiration (AIAM1-DEL-023).
-- Revocation of a delegating agent MUST cascade to all downstream delegated authority by default (AIAM1-DEL-024, see below and [REVOCATION](AEGIS_AIAM1_REVOCATION.md)).
+- Revocation of a delegating agent MUST cascade to all downstream delegated authority by default (AIAM1-DEL-024, see below and [REVOCATION](/identity/revocation/)).
 
 ---
 

--- a/site/src/content/docs/identity/identity.md
+++ b/site/src/content/docs/identity/identity.md
@@ -5,7 +5,7 @@ description: "AIAM-1 identity model — composite agent identity and principal c
 
 # AEGIS AIAM-1: Identity
 
-**Document**: AIAM-1/Identity (AEGIS_AIAM1_IDENTITY.md)\
+**Document**: AIAM-1/Identity (/identity/identity/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -125,7 +125,7 @@ AIAM-1's four dimensions answer all four questions. Each is independently verifi
 
 > **Conformance note:** Conformance assessment of goal context specificity is a subjective judgment. Third-party assessors SHOULD flag goal contexts whose `scope` field is under 20 characters or lacks resource/action qualifiers as candidates for rejection. The examples above illustrate the expected level of specificity; implementations SHOULD use them as calibration references.
 
-**AIAM1-ID-032.** Goal context is the bridge between identity and intent. Intent claims (see [INTENT](AEGIS_AIAM1_INTENT.md)) are validated against the goal context declared in the identity claim. An action whose intent does not align with the declared goal context is a candidate for denial.
+**AIAM1-ID-032.** Goal context is the bridge between identity and intent. Intent claims (see [INTENT](/identity/intent/)) are validated against the goal context declared in the identity claim. An action whose intent does not align with the declared goal context is a candidate for denial.
 
 ### 3.5 Principal
 
@@ -153,9 +153,9 @@ AIAM-1's four dimensions answer all four questions. Each is independently verifi
 
 **AIAM1-ID-052.** Identity claims MUST be revocable at any time by the issuing authority or by an authorized principal.
 
-**AIAM1-ID-053.** Revocation of an identity claim MUST take effect within the revocation propagation latency guarantee defined by the implementation (see [REVOCATION](AEGIS_AIAM1_REVOCATION.md)).
+**AIAM1-ID-053.** Revocation of an identity claim MUST take effect within the revocation propagation latency guarantee defined by the implementation (see [REVOCATION](/identity/revocation/)).
 
-**AIAM1-ID-054.** Identity claim issuance, renewal, and revocation events MUST produce attestation records (see [ATTESTATION](AEGIS_AIAM1_ATTESTATION.md)).
+**AIAM1-ID-054.** Identity claim issuance, renewal, and revocation events MUST produce attestation records (see [ATTESTATION](/identity/attestation/)).
 
 ---
 

--- a/site/src/content/docs/identity/index.md
+++ b/site/src/content/docs/identity/index.md
@@ -5,7 +5,7 @@ description: "AIAM-1 specification suite — identity and access management for 
 
 # AEGIS AIAM-1 Specification Suite
 
-**Document**: AIAM-1/Index (AEGIS_AIAM1_INDEX.md)\
+**Document**: AIAM-1/Index (/identity/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -35,17 +35,17 @@ Attempting to govern AI agents with existing IAM primitives results in agents th
 
 | Primitive | Purpose | Specification Chapter |
 |---|---|---|
-| **Composite Identity** | Four-dimensional agent identity: model provenance, orchestration layer, goal context, principal | [IDENTITY](AEGIS_AIAM1_IDENTITY.md) |
-| **Intent Claims** | Structured assertions of purpose at the moment of action | [INTENT](AEGIS_AIAM1_INTENT.md) |
-| **Intent-Bound Access Control (IBAC)** | Authorization as a function of (identity, action, intent) | [AUTHORITY](AEGIS_AIAM1_AUTHORITY.md) |
-| **Capability Scoping** | Time-bounded, non-transitive, composition-governed capabilities | [CAPABILITIES](AEGIS_AIAM1_CAPABILITIES.md) |
-| **Delegation & Principal Chains** | Explicit accountability chains with monotonic authority narrowing | [DELEGATION](AEGIS_AIAM1_DELEGATION.md) |
-| **Session Governance** | Sessions as first-class governance boundaries | [SESSIONS](AEGIS_AIAM1_SESSIONS.md) |
-| **Attestation Records** | Action-level tamper-evident proof of governance decisions | [ATTESTATION](AEGIS_AIAM1_ATTESTATION.md) |
-| **Revocation & Kill-Switch** | Pre-action revocation with propagation latency guarantees | [REVOCATION](AEGIS_AIAM1_REVOCATION.md) |
-| **Interoperability** | Mappings to OAuth 2.1, OIDC, SCIM, SAML | [INTEROPERABILITY](AEGIS_AIAM1_INTEROPERABILITY.md) |
-| **Threat Model** | Seven threat classes specific to agent IAM | [THREAT MODEL](AEGIS_AIAM1_THREAT_MODEL.md) |
-| **Conformance** | Requirements checklist and conformance profiles | [CONFORMANCE](AEGIS_AIAM1_CONFORMANCE.md) |
+| **Composite Identity** | Four-dimensional agent identity: model provenance, orchestration layer, goal context, principal | [IDENTITY](/identity/identity/) |
+| **Intent Claims** | Structured assertions of purpose at the moment of action | [INTENT](/identity/intent/) |
+| **Intent-Bound Access Control (IBAC)** | Authorization as a function of (identity, action, intent) | [AUTHORITY](/identity/authority/) |
+| **Capability Scoping** | Time-bounded, non-transitive, composition-governed capabilities | [CAPABILITIES](/identity/capabilities/) |
+| **Delegation & Principal Chains** | Explicit accountability chains with monotonic authority narrowing | [DELEGATION](/identity/delegation/) |
+| **Session Governance** | Sessions as first-class governance boundaries | [SESSIONS](/identity/sessions/) |
+| **Attestation Records** | Action-level tamper-evident proof of governance decisions | [ATTESTATION](/identity/attestation/) |
+| **Revocation & Kill-Switch** | Pre-action revocation with propagation latency guarantees | [REVOCATION](/identity/revocation/) |
+| **Interoperability** | Mappings to OAuth 2.1, OIDC, SCIM, SAML | [INTEROPERABILITY](/identity/interoperability/) |
+| **Threat Model** | Seven threat classes specific to agent IAM | [THREAT MODEL](/identity/threat-model/) |
+| **Conformance** | Requirements checklist and conformance profiles | [CONFORMANCE](/identity/conformance/) |
 
 ### 1.3 Out of Scope
 
@@ -131,18 +131,18 @@ IBAC strictly generalizes prior models: an RBAC policy is an IBAC triple where t
 
 | Document | Status | Description |
 |---|---|---|
-| [AEGIS_AIAM1_INDEX.md](AEGIS_AIAM1_INDEX.md) | Draft | This document. Suite index and overview. |
-| [AEGIS_AIAM1_IDENTITY.md](AEGIS_AIAM1_IDENTITY.md) | Draft | Composite identity model, cryptographic attestation, JSON schema. |
-| [AEGIS_AIAM1_INTENT.md](AEGIS_AIAM1_INTENT.md) | Draft | Intent claims as structured assertions, validation, spoofing detection. |
-| [AEGIS_AIAM1_AUTHORITY.md](AEGIS_AIAM1_AUTHORITY.md) | Draft | Intent-Bound Access Control (IBAC), authority binding triples, policy format. |
-| [AEGIS_AIAM1_CAPABILITIES.md](AEGIS_AIAM1_CAPABILITIES.md) | Draft | Capability scoping, composition governance, non-transitivity, revocation. |
-| [AEGIS_AIAM1_DELEGATION.md](AEGIS_AIAM1_DELEGATION.md) | Draft | Principal chains, monotonic authority narrowing, delegation depth limits. |
-| [AEGIS_AIAM1_SESSIONS.md](AEGIS_AIAM1_SESSIONS.md) | Draft | Session as governance boundary, four-dimensional bounding. |
-| [AEGIS_AIAM1_ATTESTATION.md](AEGIS_AIAM1_ATTESTATION.md) | Draft | Attestation records, tamper-evidence, retention. |
-| [AEGIS_AIAM1_REVOCATION.md](AEGIS_AIAM1_REVOCATION.md) | Draft | Kill-switch, propagation latency, pre-action enforcement. |
-| [AEGIS_AIAM1_INTEROPERABILITY.md](AEGIS_AIAM1_INTEROPERABILITY.md) | Draft | OAuth 2.1, OIDC, SCIM, SAML mappings. |
-| [AEGIS_AIAM1_THREAT_MODEL.md](AEGIS_AIAM1_THREAT_MODEL.md) | Draft | Seven threat classes, ATX-1 cross-references, residual risk. |
-| [AEGIS_AIAM1_CONFORMANCE.md](AEGIS_AIAM1_CONFORMANCE.md) | Draft | Conformance checklist, profiles, conformance statements. |
+| [AEGIS_AIAM1_INDEX.md](/identity/) | Draft | This document. Suite index and overview. |
+| [AEGIS_AIAM1_IDENTITY.md](/identity/identity/) | Draft | Composite identity model, cryptographic attestation, JSON schema. |
+| [AEGIS_AIAM1_INTENT.md](/identity/intent/) | Draft | Intent claims as structured assertions, validation, spoofing detection. |
+| [AEGIS_AIAM1_AUTHORITY.md](/identity/authority/) | Draft | Intent-Bound Access Control (IBAC), authority binding triples, policy format. |
+| [AEGIS_AIAM1_CAPABILITIES.md](/identity/capabilities/) | Draft | Capability scoping, composition governance, non-transitivity, revocation. |
+| [AEGIS_AIAM1_DELEGATION.md](/identity/delegation/) | Draft | Principal chains, monotonic authority narrowing, delegation depth limits. |
+| [AEGIS_AIAM1_SESSIONS.md](/identity/sessions/) | Draft | Session as governance boundary, four-dimensional bounding. |
+| [AEGIS_AIAM1_ATTESTATION.md](/identity/attestation/) | Draft | Attestation records, tamper-evidence, retention. |
+| [AEGIS_AIAM1_REVOCATION.md](/identity/revocation/) | Draft | Kill-switch, propagation latency, pre-action enforcement. |
+| [AEGIS_AIAM1_INTEROPERABILITY.md](/identity/interoperability/) | Draft | OAuth 2.1, OIDC, SCIM, SAML mappings. |
+| [AEGIS_AIAM1_THREAT_MODEL.md](/identity/threat-model/) | Draft | Seven threat classes, ATX-1 cross-references, residual risk. |
+| [AEGIS_AIAM1_CONFORMANCE.md](/identity/conformance/) | Draft | Conformance checklist, profiles, conformance statements. |
 
 ### 5.2 Schemas
 
@@ -165,7 +165,7 @@ IBAC strictly generalizes prior models: an RBAC policy is an IBAC triple where t
 
 | Document | Location | Description |
 |---|---|---|
-| [AIAM-1-position-paper-v0.1.md](../docs/position-papers/aiam/AIAM-1-position-paper-v0.1.md) | `docs/position-papers/aiam/` | Position paper establishing the normative scope of AIAM-1 v0.1. |
+| [AIAM-1-position-paper-v0.1.md](https://github.com/aegis-initiative/aegis-governance/blob/main/docs/position-papers/aiam/AIAM-1-position-paper-v0.1.md) | `docs/position-papers/aiam/` | Position paper establishing the normative scope of AIAM-1 v0.1. |
 
 ---
 

--- a/site/src/content/docs/identity/intent.md
+++ b/site/src/content/docs/identity/intent.md
@@ -5,7 +5,7 @@ description: "AIAM-1 intent claims — structured purpose assertions at moment o
 
 # AEGIS AIAM-1: Intent
 
-**Document**: AIAM-1/Intent (AEGIS_AIAM1_INTENT.md)\
+**Document**: AIAM-1/Intent (/identity/intent/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -95,7 +95,7 @@ AGP-1 deployments that do not adopt AIAM-1 continue to function without intent c
 
 ### 3.3 Intent Claim Preservation
 
-**AIAM1-INT-020.** Intent claims MUST be preserved as part of the attestation record for every action (see [ATTESTATION](AEGIS_AIAM1_ATTESTATION.md)).
+**AIAM1-INT-020.** Intent claims MUST be preserved as part of the attestation record for every action (see [ATTESTATION](/identity/attestation/)).
 
 **AIAM1-INT-021.** Intent claims MUST NOT be modifiable after production. Once an intent claim is submitted with an action proposal, it is immutable. Any correction requires a new action proposal with a new intent claim.
 
@@ -113,7 +113,7 @@ AGP-1 deployments that do not adopt AIAM-1 continue to function without intent c
 
 ### Scenario
 
-The Acme SOC triage agent (identity claim from [IDENTITY §6](AEGIS_AIAM1_IDENTITY.md#6-worked-example-single-principal-single-agent)) detects an anomalous spike in DNS queries from a specific host. It decides to query the SIEM for related network telemetry.
+The Acme SOC triage agent (identity claim from [IDENTITY §6](/identity/identity/#6-worked-example-single-principal-single-agent)) detects an anomalous spike in DNS queries from a specific host. It decides to query the SIEM for related network telemetry.
 
 ### Intent Claim
 

--- a/site/src/content/docs/identity/interoperability.md
+++ b/site/src/content/docs/identity/interoperability.md
@@ -5,7 +5,7 @@ description: "AIAM-1 interoperability — cross-system identity federation"
 
 # AEGIS AIAM-1: Interoperability
 
-**Document**: AIAM-1/Interoperability (AEGIS_AIAM1_INTEROPERABILITY.md)\
+**Document**: AIAM-1/Interoperability (/identity/interoperability/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026

--- a/site/src/content/docs/identity/revocation.md
+++ b/site/src/content/docs/identity/revocation.md
@@ -5,7 +5,7 @@ description: "AIAM-1 revocation — credential and authority withdrawal"
 
 # AEGIS AIAM-1: Revocation and Kill-Switch Semantics
 
-**Document**: AIAM-1/Revocation (AEGIS_AIAM1_REVOCATION.md)\
+**Document**: AIAM-1/Revocation (/identity/revocation/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -123,7 +123,7 @@ Acme Corp's SOC monitoring detects that agent `agent:soc-forensics` has been com
 
 1. `agent:soc-forensics` identity claim is revoked.
 2. All sessions held by `agent:soc-forensics` are terminated.
-3. All delegations from `agent:soc-forensics` are revoked — including `agent:dns-log-reader`'s delegated `telemetry.query` capability (cascade from [DELEGATION §4](AEGIS_AIAM1_DELEGATION.md#4-worked-example-multi-agent-delegation)).
+3. All delegations from `agent:soc-forensics` are revoked — including `agent:dns-log-reader`'s delegated `telemetry.query` capability (cascade from [DELEGATION §4](/identity/delegation/#4-worked-example-multi-agent-delegation)).
 4. Any in-flight action proposals from `agent:soc-forensics` or `agent:dns-log-reader` (using delegated authority) are denied.
 5. `agent:dns-log-reader`'s independent capability grants (if any) remain active.
 

--- a/site/src/content/docs/identity/sessions.md
+++ b/site/src/content/docs/identity/sessions.md
@@ -5,7 +5,7 @@ description: "AIAM-1 session management — governance-aware session lifecycle"
 
 # AEGIS AIAM-1: Session Semantics
 
-**Document**: AIAM-1/Sessions (AEGIS_AIAM1_SESSIONS.md)\
+**Document**: AIAM-1/Sessions (/identity/sessions/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026

--- a/site/src/content/docs/identity/threat-model.md
+++ b/site/src/content/docs/identity/threat-model.md
@@ -5,7 +5,7 @@ description: "AIAM-1 threat model — identity-specific attack surfaces"
 
 # AEGIS AIAM-1: Threat Model
 
-**Document**: AIAM-1/Threat Model (AEGIS_AIAM1_THREAT_MODEL.md)\
+**Document**: AIAM-1/Threat Model (/identity/threat-model/)\
 **Version**: 0.1 (Draft)\
 **Part of**: AEGIS Identity & Access Management for AI Agents\
 **Last Updated**: April 10, 2026
@@ -134,7 +134,7 @@ AIAM-1 identifies eight threat classes. For each threat class, this chapter spec
 
 ### 2.8 TC-8: Cross-Authority Composition
 
-**Description.** A sub-agent combines delegated authority from principal A with independent authority granted under principal B to produce an effect that neither principal alone authorized. This is the delegated/independent authority seam (see [DELEGATION §5.1](AEGIS_AIAM1_DELEGATION.md#51-authority-source-composition)) elevated to a first-class threat. Unlike TC-2 (capability composition), which concerns sequences of capabilities under a single authority source, TC-8 concerns the mixing of authority sources themselves.
+**Description.** A sub-agent combines delegated authority from principal A with independent authority granted under principal B to produce an effect that neither principal alone authorized. This is the delegated/independent authority seam (see [DELEGATION §5.1](/identity/delegation/#51-authority-source-composition)) elevated to a first-class threat. Unlike TC-2 (capability composition), which concerns sequences of capabilities under a single authority source, TC-8 concerns the mixing of authority sources themselves.
 
 **Example.** Agent X holds:
 - Delegated capability `patient.query` from Hospital A's EHR system (principal: Hospital A)

--- a/site/src/content/docs/protocol/authentication.md
+++ b/site/src/content/docs/protocol/authentication.md
@@ -5,7 +5,7 @@ description: "AGP-1 authentication — identity verification and binding"
 
 # AEGIS AGP-1 Authentication & Authorization
 
-**Document**: AGP-1/Auth (AEGIS_AGP1_AUTHENTICATION.md)\
+**Document**: AGP-1/Auth (/protocol/authentication/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **Last Updated**: March 6, 2026
@@ -404,11 +404,11 @@ If token must be revoked before expiration (compromise):
 
 ### Next Steps
 
-- [AEGIS_AGP1_POLICY_EVALUATION.md](./AEGIS_AGP1_POLICY_EVALUATION.md) - Capability and policy evaluation
-- [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md) - Complete protocol flows
+- [AEGIS_AGP1_POLICY_EVALUATION.md](/protocol/policy-evaluation/) - Capability and policy evaluation
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Complete protocol flows
 
 ---
 
 ### References
 
-[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. See [REFERENCES.md](../../REFERENCES.md).
+[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/index.md
+++ b/site/src/content/docs/protocol/index.md
@@ -5,7 +5,7 @@ description: "AGP-1 specification suite index — the AEGIS governance protocol"
 
 # AEGIS AGP-1 Complete Specification Suite & Index
 
-**Document**: AGP-1/Index (AEGIS_AGP1_INDEX.md)\
+**Document**: AGP-1/Index (/protocol/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **Last Updated**: March 6, 2026
@@ -40,13 +40,13 @@ This specification suite consists of **9 modular documents** organized by domain
 
 ### Core Protocol (Read in this order)
 
-1. **[AEGIS_AGP1_OVERVIEW.md](./AEGIS_AGP1_OVERVIEW.md)** - Protocol overview, principles, and design rationale
+1. **[AEGIS_AGP1_OVERVIEW.md](/protocol/overview/)** - Protocol overview, principles, and design rationale
    - Purpose and scope
    - Core principles (determinism, default-deny, attribution, auditable)
    - Message categories
    - Integration with RFCs and federation
 
-2. **[AEGIS_AGP1_MESSAGES.md](./AEGIS_AGP1_MESSAGES.md)** - Complete message schemas and field specifications
+2. **[AEGIS_AGP1_MESSAGES.md](/protocol/messages/)** - Complete message schemas and field specifications
    - ACTION_PROPOSE schema with 15+ fields
    - DECISION_RESPONSE schema with decision outcomes
    - EXECUTION_REPORT for outcome tracking
@@ -54,21 +54,21 @@ This specification suite consists of **9 modular documents** organized by domain
    - AUDIT_QUERY for evidence retrieval
    - HEALTH_CHECK for connectivity testing
 
-3. **[AEGIS_AGP1_WIRE_FORMAT.md](./AEGIS_AGP1_WIRE_FORMAT.md)** - Transport, serialization, and encoding
+3. **[AEGIS_AGP1_WIRE_FORMAT.md](/protocol/wire-format/)** - Transport, serialization, and encoding
    - HTTP/1.1 and HTTP/2 endpoints and methods
    - Protocol Buffers alternative format
    - Request/response envelopes
    - Content encoding (JSON, gzip, protobuf)
    - Header specifications
 
-4. **[AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)** - Protocol flows, diagrams, and state machines
+4. **[AEGIS_AGP1_INDEX.md](/protocol/)** - Protocol flows, diagrams, and state machines
    - Happy path (allow decision)
    - Escalation flow (human review)
    - Comprehensive decision tree
    - Complete state machine with all paths
    - Justification for flow design
 
-5. **[AEGIS_AGP1_AUTHENTICATION.md](./AEGIS_AGP1_AUTHENTICATION.md)** - Authentication and authorization
+5. **[AEGIS_AGP1_AUTHENTICATION.md](/protocol/authentication/)** - Authentication and authorization
    - Bearer tokens with JWT claims
    - Mutual TLS (mTLS) certificate validation
    - API key authentication (deprecated)
@@ -77,14 +77,14 @@ This specification suite consists of **9 modular documents** organized by domain
 
 ### Decision Logic (Critical for evaluation)
 
-1. **[AEGIS_AGP1_POLICY_EVALUATION.md](./AEGIS_AGP1_POLICY_EVALUATION.md)** - Capability registry and policy evaluation
+1. **[AEGIS_AGP1_POLICY_EVALUATION.md](/protocol/policy-evaluation/)** - Capability registry and policy evaluation
    - Integration with RFC-0003 Capability Registry
    - Policy language specification with examples
    - Capability inheritance and composition
    - Conflict resolution (precedence rules)
    - Deterministic evaluation algorithm
 
-2. **[AEGIS_AGP1_RISK_SCORING.md](./AEGIS_AGP1_RISK_SCORING.md)** - Risk assessment and decision logic
+2. **[AEGIS_AGP1_RISK_SCORING.md](/protocol/risk-scoring/)** - Risk assessment and decision logic
    - 5-factor risk scoring model with weights
    - Historical attempt rate calculations
    - Actor reputation/trust integration
@@ -96,14 +96,14 @@ This specification suite consists of **9 modular documents** organized by domain
 
 ### Operational Specifications
 
-1. **[AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)** - Error handling and recovery
+1. **[AEGIS_AGP1_INDEX.md](/protocol/)** - Error handling and recovery
    - Error response envelope format
    - 15 error codes with HTTP mappings
    - Retryable vs. non-retryable errors
    - Exponential backoff strategies
    - Timeout and deadline handling
 
-2. **[AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)** - Deployment, configuration, and operations
+2. **[AEGIS_AGP1_INDEX.md](/protocol/)** - Deployment, configuration, and operations
    - Deployment topologies (single-instance, HA, authority nodes)
    - Performance requirements and SLOs
    - Kubernetes and Docker examples
@@ -240,21 +240,21 @@ A client implementation MUST:
 
 ### AEGIS Core Specifications
 
-- [RFC-0001: AEGIS Architecture](../../rfc/RFC-0001-AEGIS-Architecture.md)
-- [RFC-0002: Governance Runtime](../../rfc/RFC-0002-Governance-Runtime.md)
-- [RFC-0003: Capability Registry](../../rfc/RFC-0003-Capability-Registry.md)
-- [RFC-0004: Governance Event Model](../../rfc/RFC-0004-Governance-Event-Model.md)
+- [RFC-0001: AEGIS Architecture](/rfc/0001/)
+- [RFC-0002: Governance Runtime](/rfc/0002/)
+- [RFC-0003: Capability Registry](/rfc/0003/)
+- [RFC-0004: Governance Event Model](/rfc/0004/)
 
 ### Federation Specifications
 
-- [AEGIS Node Reference Architecture](../../federation/AEGIS_GFN1_NODE_REFERENCE_ARCHITECTURE.md)
-- [AEGIS Trust Model](../../federation/AEGIS_GFN1_TRUST_MODEL.md)
-- [Federation README with Reading Order](../../federation/README.md)
+- [AEGIS Node Reference Architecture](/federation/node-architecture/)
+- [AEGIS Trust Model](/federation/trust-model/)
+- [Federation README with Reading Order](/federation/)
 
 ### Supporting Documents
 
 - [AEGIS Constitution](https://aegis-constitution.com) - Governance principles
-- [AEGIS Threat Model](../../aegis-core/threat-model/AEGIS_ATM1_INDEX.md) - Security analysis
+- [AEGIS Threat Model](/threat-model/) - Security analysis
 
 ---
 
@@ -262,32 +262,32 @@ A client implementation MUST:
 
 ### For Implementers (Building AGP-1 Servers)
 
-1. Start with [AEGIS_AGP1_OVERVIEW.md](./AEGIS_AGP1_OVERVIEW.md) to understand principles
-2. Review [AEGIS_AGP1_MESSAGES.md](./AEGIS_AGP1_MESSAGES.md) for exact schemas
-3. Implement message parsing and validation per [AEGIS_AGP1_WIRE_FORMAT.md](./AEGIS_AGP1_WIRE_FORMAT.md)
-4. Integrate policy evaluation per [AEGIS_AGP1_POLICY_EVALUATION.md](./AEGIS_AGP1_POLICY_EVALUATION.md)
-5. Implement risk scoring per [AEGIS_AGP1_RISK_SCORING.md](./AEGIS_AGP1_RISK_SCORING.md)
-6. Add error handling per [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)
-7. Deploy per [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)
+1. Start with [AEGIS_AGP1_OVERVIEW.md](/protocol/overview/) to understand principles
+2. Review [AEGIS_AGP1_MESSAGES.md](/protocol/messages/) for exact schemas
+3. Implement message parsing and validation per [AEGIS_AGP1_WIRE_FORMAT.md](/protocol/wire-format/)
+4. Integrate policy evaluation per [AEGIS_AGP1_POLICY_EVALUATION.md](/protocol/policy-evaluation/)
+5. Implement risk scoring per [AEGIS_AGP1_RISK_SCORING.md](/protocol/risk-scoring/)
+6. Add error handling per [AEGIS_AGP1_INDEX.md](/protocol/)
+7. Deploy per [AEGIS_AGP1_INDEX.md](/protocol/)
 
 ### For Client Developers (Calling AGP-1 Runtimes)
 
-1. Review [AEGIS_AGP1_OVERVIEW.md](./AEGIS_AGP1_OVERVIEW.md) for protocol overview
-2. Learn message structure from [AEGIS_AGP1_MESSAGES.md](./AEGIS_AGP1_MESSAGES.md)
-3. Implement authentication per [AEGIS_AGP1_AUTHENTICATION.md](./AEGIS_AGP1_AUTHENTICATION.md)
-4. Handle all decision outcomes from [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)
-5. Implement error handling from [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)
+1. Review [AEGIS_AGP1_OVERVIEW.md](/protocol/overview/) for protocol overview
+2. Learn message structure from [AEGIS_AGP1_MESSAGES.md](/protocol/messages/)
+3. Implement authentication per [AEGIS_AGP1_AUTHENTICATION.md](/protocol/authentication/)
+4. Handle all decision outcomes from [AEGIS_AGP1_INDEX.md](/protocol/)
+5. Implement error handling from [AEGIS_AGP1_INDEX.md](/protocol/)
 
 ### For Policy Authors
 
-1. Review policy evaluation in [AEGIS_AGP1_POLICY_EVALUATION.md](./AEGIS_AGP1_POLICY_EVALUATION.md)
+1. Review policy evaluation in [AEGIS_AGP1_POLICY_EVALUATION.md](/protocol/policy-evaluation/)
 2. Study policy language syntax and examples
 3. Understand capability resolution and inheritance
 4. Review conflict resolution rules for ordering policies
 
 ### For Risk Analysts
 
-1. Review risk scoring in [AEGIS_AGP1_RISK_SCORING.md](./AEGIS_AGP1_RISK_SCORING.md)
+1. Review risk scoring in [AEGIS_AGP1_RISK_SCORING.md](/protocol/risk-scoring/)
 2. Understand 5-factor risk model and weights
 3. Review risk-based decision thresholds
 4. Analyze confidence score calculations
@@ -311,6 +311,6 @@ All AEGIS governance specifications are published under the AEGIS Governance fra
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/messages.md
+++ b/site/src/content/docs/protocol/messages.md
@@ -5,7 +5,7 @@ description: "AGP-1 message types — proposals, decisions, and audit records"
 
 # AEGIS AGP-1 Message Schemas & Field Specifications
 
-**Document**: AGP-1/Messages (AEGIS_AGP1_MESSAGES.md)\
+**Document**: AGP-1/Messages (/protocol/messages/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **Last Updated**: March 6, 2026
@@ -658,5 +658,5 @@ Action permitted only with explicit user confirmation.
 
 ## Next Steps
 
-- [AEGIS_AGP1_WIRE_FORMAT.md](./AEGIS_AGP1_WIRE_FORMAT.md) - HTTP/2 endpoints, serialization, encoding
-- [AEGIS_AGP1_AUTHENTICATION.md](./AEGIS_AGP1_AUTHENTICATION.md) - How to authenticate with bearer tokens and mTLS
+- [AEGIS_AGP1_WIRE_FORMAT.md](/protocol/wire-format/) - HTTP/2 endpoints, serialization, encoding
+- [AEGIS_AGP1_AUTHENTICATION.md](/protocol/authentication/) - How to authenticate with bearer tokens and mTLS

--- a/site/src/content/docs/protocol/overview.md
+++ b/site/src/content/docs/protocol/overview.md
@@ -5,7 +5,7 @@ description: "AGP-1 protocol overview — design goals, scope, and terminology"
 
 # AEGIS AGP-1 Protocol Overview & Design Principles
 
-**Document**: AGP-1/Overview (AEGIS_AGP1_OVERVIEW.md)\
+**Document**: AGP-1/Overview (/protocol/overview/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **Last Updated**: March 6, 2026
@@ -299,14 +299,14 @@ AGP-1 does **NOT** address:
 
 Continue reading:
 
-1. **[AEGIS_AGP1_MESSAGES.md](./AEGIS_AGP1_MESSAGES.md)** - Exact message schemas and field specifications
-2. **[AEGIS_AGP1_AUTHENTICATION.md](./AEGIS_AGP1_AUTHENTICATION.md)** - How to authenticate as a client
-3. **[AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md)** - Visual protocol flows and state machines
+1. **[AEGIS_AGP1_MESSAGES.md](/protocol/messages/)** - Exact message schemas and field specifications
+2. **[AEGIS_AGP1_AUTHENTICATION.md](/protocol/authentication/)** - How to authenticate as a client
+3. **[AEGIS_AGP1_INDEX.md](/protocol/)** - Visual protocol flows and state machines
 
 ---
 
 ## References
 
-[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Web Service Message Contracts with Data," *IEEE Transactions on Services Computing*, vol. 5, no. 2, pp. 192–206, April–June 2012, doi: 10.1109/TSC.2011.10. See [REFERENCES.md](../../REFERENCES.md).
+[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Web Service Message Contracts with Data," *IEEE Transactions on Services Computing*, vol. 5, no. 2, pp. 192–206, April–June 2012, doi: 10.1109/TSC.2011.10. See [REFERENCES.md](/references/).
 
-[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/policy-evaluation.md
+++ b/site/src/content/docs/protocol/policy-evaluation.md
@@ -5,7 +5,7 @@ description: "AGP-1 policy evaluation — matching, resolution, and enforcement"
 
 # AEGIS AGP-1 Policy Evaluation & Capability Resolution
 
-**Document**: AGP-1/Policy (AEGIS_AGP1_POLICY_EVALUATION.md)\
+**Document**: AGP-1/Policy (/protocol/policy-evaluation/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **References**: RFC-0003 (Capability Registry)\
@@ -450,15 +450,15 @@ Results:
 
 ### Next Steps
 
-- [AEGIS_AGP1_RISK_SCORING.md](./AEGIS_AGP1_RISK_SCORING.md) - Risk calculation and decision thresholds
-- [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md) - Complete protocol flows with policy evaluation
+- [AEGIS_AGP1_RISK_SCORING.md](/protocol/risk-scoring/) - Risk calculation and decision thresholds
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Complete protocol flows with policy evaluation
 
 ---
 
 ### References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](../../REFERENCES.md).
+[^14]: Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/risk-scoring.md
+++ b/site/src/content/docs/protocol/risk-scoring.md
@@ -5,7 +5,7 @@ description: "AGP-1 risk scoring — threat quantification within the protocol"
 
 # AEGIS AGP-1 Risk Scoring & Decision Thresholds
 
-**Document**: AGP-1/Risk (AEGIS_AGP1_RISK_SCORING.md)\
+**Document**: AGP-1/Risk (/protocol/risk-scoring/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **References**: AGP-1/Trust, GFN-1/Nodes\
@@ -446,11 +446,11 @@ test_case: "high_risk_production_at_3am"
 
 ### Next Steps
 
-- [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md) - Complete decision flows with risk thresholds
-- [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md) - Error codes and retry logic
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Complete decision flows with risk thresholds
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Error codes and retry logic
 
 ---
 
 ### References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/trust-model.md
+++ b/site/src/content/docs/protocol/trust-model.md
@@ -5,7 +5,7 @@ description: "AGP-1 trust model — two-layer agent admissibility"
 
 # AEGIS AGP-1 Trust Model & Actor Reputation
 
-**Document**: AGP-1/Trust (AEGIS_AGP1_TRUST_MODEL.md)\
+**Document**: AGP-1/Trust (/protocol/trust-model/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **References**: AGP-1/Risk, GFN-1/Nodes\
@@ -17,7 +17,7 @@ description: "AGP-1 trust model — two-layer agent admissibility"
 
 The AEGIS Trust Model establishes a **capability-based reputation system** for actors (users, services, LLMs) in a federated governance environment. Each actor has a trust score [0.0 - 1.0] that influences:
 
-1. **Decision thresholds** (AEGIS_AGP1_RISK_SCORING.md)
+1. **Decision thresholds** (/protocol/risk-scoring/)
 2. **Escalation requirements** (when human review is needed)
 3. **Monitoring constraints** (how closely the execution is observed)
 4. **Federation participation** (whether signals from this actor are trusted)
@@ -373,20 +373,20 @@ All trust calculations are logged:
 
 ### Next Steps
 
-- [AEGIS_AGP1_POLICY_EVALUATION.md](./AEGIS_AGP1_POLICY_EVALUATION.md) - Policy rules that use trust scores
-- [AEGIS_AGP1_RISK_SCORING.md](./AEGIS_AGP1_RISK_SCORING.md) - Complete risk scoring calculations
-- [AEGIS_GFN1_NODE_REFERENCE_ARCHITECTURE.md](../../federation/AEGIS_GFN1_NODE_REFERENCE_ARCHITECTURE.md) - Trust evaluator component
+- [AEGIS_AGP1_POLICY_EVALUATION.md](/protocol/policy-evaluation/) - Policy rules that use trust scores
+- [AEGIS_AGP1_RISK_SCORING.md](/protocol/risk-scoring/) - Complete risk scoring calculations
+- [AEGIS_GFN1_NODE_REFERENCE_ARCHITECTURE.md](/federation/node-architecture/) - Trust evaluator component
 
 ---
 
 ### References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).
 
-[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc8705>. See [REFERENCES.md](../../REFERENCES.md).
+[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc8705>. See [REFERENCES.md](/references/).
 
-[^20]: M. Sporny, A. Guy, M. Sabadello, and D. Reed, "Decentralized Identifiers (DIDs) v1.0: Core architecture, data model, and representations," W3C Recommendation, 19 Jul. 2022. [Online]. Available: <https://www.w3.org/TR/2022/REC-did-core-20220719/>. See [REFERENCES.md](../../REFERENCES.md).
+[^20]: M. Sporny, A. Guy, M. Sabadello, and D. Reed, "Decentralized Identifiers (DIDs) v1.0: Core architecture, data model, and representations," W3C Recommendation, 19 Jul. 2022. [Online]. Available: <https://www.w3.org/TR/2022/REC-did-core-20220719/>. See [REFERENCES.md](/references/).
 
-[^25]: S. Rodriguez Garzon et al., "AI Agents with Decentralized Identifiers and Verifiable Credentials," arXiv:2511.02841v2, 2025. [Online]. Available: <https://arxiv.org/abs/2511.02841>. See [REFERENCES.md](../../REFERENCES.md).
+[^25]: S. Rodriguez Garzon et al., "AI Agents with Decentralized Identifiers and Verifiable Credentials," arXiv:2511.02841v2, 2025. [Online]. Available: <https://arxiv.org/abs/2511.02841>. See [REFERENCES.md](/references/).
 
-[^26]: A. Jøsang, R. Ismail, and C. Boyd, "A survey of trust and reputation systems for online service provision," *Decision Support Systems*, vol. 43, no. 2, pp. 618–644, Mar. 2007, doi: 10.1016/j.dss.2005.05.019. See [REFERENCES.md](../../REFERENCES.md).
+[^26]: A. Jøsang, R. Ismail, and C. Boyd, "A survey of trust and reputation systems for online service provision," *Decision Support Systems*, vol. 43, no. 2, pp. 618–644, Mar. 2007, doi: 10.1016/j.dss.2005.05.019. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/protocol/wire-format.md
+++ b/site/src/content/docs/protocol/wire-format.md
@@ -5,7 +5,7 @@ description: "AGP-1 wire format — serialization and transport encoding"
 
 # AEGIS AGP-1 Wire Format & Transport Specification
 
-**Document**: AGP-1/Wire (AEGIS_AGP1_WIRE_FORMAT.md)\
+**Document**: AGP-1/Wire (/protocol/wire-format/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Governance Protocol\
 **Last Updated**: March 6, 2026
@@ -315,5 +315,5 @@ header("X-Signature") = base64url(signature)
 
 ## Next Steps
 
-- [AEGIS_AGP1_AUTHENTICATION.md](./AEGIS_AGP1_AUTHENTICATION.md) - OAuth, JWT, mTLS details
-- [AEGIS_AGP1_INDEX.md](./AEGIS_AGP1_INDEX.md) - Full protocol flows and diagrams
+- [AEGIS_AGP1_AUTHENTICATION.md](/protocol/authentication/) - OAuth, JWT, mTLS details
+- [AEGIS_AGP1_INDEX.md](/protocol/) - Full protocol flows and diagrams

--- a/site/src/content/docs/references.md
+++ b/site/src/content/docs/references.md
@@ -3,6 +3,8 @@ title: References
 description: Canonical bibliography for the AEGIS governance framework — all papers cited in specs, RFCs, threat model, and protocol documents.
 ---
 
+<!-- cspell:ignore Bradner Hardt Parecki Sporny Sabadello Saltzer Schroeder Schneider Agbemabiese Shapira Rasthofer Arzt Lovat Bodden Pinisetty Majumdar Arunachalam Kayyidavazhiyil Santikellur Tetragon Leike Amodei Byun Sakimura Lodderstedt Niyato Mitchell Borchert Connelly Gaithersburg Shuhan Josang Boyd Kuo Ukil Roop Baird Panda Pearce Engin Gaurav Heikkonen Chaudhary Woodruff Tapiero -->
+
 # AEGIS References
 
 Canonical bibliography for the AEGIS™ governance framework. All papers cited anywhere in the documentation appear here. Documents cite inline using IEEE footnote style and reference this page for the full entry.

--- a/site/src/content/docs/references.md
+++ b/site/src/content/docs/references.md
@@ -1,0 +1,188 @@
+---
+title: References
+description: Canonical bibliography for the AEGIS governance framework — all papers cited in specs, RFCs, threat model, and protocol documents.
+---
+
+# AEGIS References
+
+Canonical bibliography for the AEGIS™ governance framework. All papers cited anywhere in the documentation appear here. Documents cite inline using IEEE footnote style and reference this page for the full entry.
+
+---
+
+## Foundational Security Theory
+
+[1] J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. [Online]. Available: <https://csrc.nist.gov/files/pubs/conference/1998/10/08/proceedings-of-the-21st-nissc-1998/final/docs/early-cs-papers/ande72.pdf>\
+**Relevance to AEGIS:** First articulation of the reference monitor — a component that validates all references made by executing programs against those authorized for the subject. The conceptual origin of every enforcement boundary AEGIS inherits. AEGIS's governance gateway is a direct descendant of this concept.
+
+[22] J. H. Saltzer and M. D. Schroeder, "The protection of information in computer systems," *Proc. IEEE*, vol. 63, no. 9, pp. 1278–1308, Sep. 1975, doi: 10.1109/PROC.1975.9939. [Online]. Available: <https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=1451869>\
+**Keywords:** Access control; least privilege; fail-safe defaults; complete mediation; open design; separation of privilege; security design principles\
+**Relevance to AEGIS:** Foundational enumeration of eight security design principles that AEGIS instantiates architecturally. Four principles map directly to AGP-1: (1) Fail-safe defaults → capability registry is empty by default; all undefined actions denied. (2) Complete mediation → every agent action passes through the governance gateway without exception. (3) Least privilege → capability grants are explicit, minimal, and scoped to specific action types and resource targets. (4) Open design → AEGIS published under Apache 2.0; security properties do not depend on obscurity. Together with Anderson [1], this paper establishes the theoretical security foundation AEGIS inherits. Anderson defines the enforcement boundary; Saltzer & Schroeder define the principles governing what that boundary enforces.
+
+[2] F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382.\
+**Keywords:** Security automata; runtime monitors; enforceable policies; safety policies\
+**Relevance to AEGIS:** Establishes the formal theory of security automata and defines which security policies are enforceable through runtime monitoring. AEGIS's deterministic enforcement model and fail-closed posture are grounded in Schneider's proof that only safety policies are inline-enforceable. The AEGIS Constitution's Article III (Deterministic Enforcement) inherits this foundation directly. Schneider also proves that composition of security automata produces the conjunction of their enforced policies — enforcing multiple automata in tandem enforces all of their policies simultaneously. This is the formal justification for AEGIS's multi-gate enforcement architecture: each gate enforces its own policy, and the composed system enforces all of them.
+
+---
+
+## Runtime & Architectural Enforcement
+
+[3] S. Hallé and R. Villemaire, "Runtime Enforcement of Web Service Message Contracts with Data," *IEEE Transactions on Services Computing*, vol. 5, no. 2, pp. 192–206, April–June 2012, doi: 10.1109/TSC.2011.10.\
+**Keywords:** Web services; runtime monitoring; temporal logic\
+**Relevance to AEGIS:** Foundational runtime contract enforcement pattern. The ACTION_PROPOSE → ACTION_DECIDE → ACTION_EXECUTE message flow follows the transparent enforcement pattern established here for web service contracts, adapted for agentic AI governance.
+
+[4] S. Rasthofer, S. Arzt, E. Lovat, and E. Bodden, "DroidForce: Enforcing Complex, Data-centric, System-wide Policies in Android," *2014 Ninth International Conference on Availability, Reliability and Security (ARES)*, Fribourg, Switzerland, 2014, pp. 40–49, doi: 10.1109/ARES.2014.13.\
+**Keywords:** Android; policy; system-wide enforcement; data flow; data-centric\
+**Relevance to AEGIS:** Establishes the centralized Policy Decision Point (PDP) + decentralized Policy Enforcement Points (PEPs) architectural pattern that AEGIS adopts. The centralized governance engine (AGP-1) mirrors DroidForce's PDP; AEGIS gates function as distributed PEPs.
+
+[5] H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520.\
+**Keywords:** Cyber-physical attacks; industrial control systems; runtime enforcement; security\
+**Relevance to AEGIS:** Boundary enforcement between controller and infrastructure directly informs AEGIS gate positioning. Establishes the compromised controller threat model — AEGIS applies this to AI agents (compromised agent assumption). The I/O module pattern is the physical analogue of the AEGIS governance gateway.
+
+[6] S. Majumdar et al., "ProSAS: Proactive Security Auditing System for Clouds," *IEEE Transactions on Dependable and Secure Computing*, vol. 19, no. 4, pp. 2517–2534, July–Aug. 2022, doi: 10.1109/TDSC.2021.3062204.\
+**Keywords:** Security auditing; runtime enforcement; cloud security; proactive auditing; continuous auditing; OpenStack\
+**Relevance to AEGIS:** Proactive, continuous security auditing in cloud environments validates AEGIS's always-on governance posture. ProSAS's probabilistic runtime enforcement complements AEGIS's deterministic enforcement model and informs the audit system design.
+
+[7] A. Baird, A. Panda, H. Pearce, S. Pinisetty, and P. Roop, "Scalable Security Enforcement for Cyber Physical Systems," *IEEE Access*, vol. 12, pp. 14385–14410, 2024, doi: 10.1109/ACCESS.2024.3357714.\
+**Keywords:** Cyber-physical systems; security; runtime enforcement; synchronous programming\
+**Relevance to AEGIS:** Compositional enforcement across heterogeneous CPS validates AEGIS's federated governance model. Demonstrates scalable enforcement without modifying underlying applications — a core AEGIS design constraint.
+
+[8] K. Arunachalam, A. Kayyidavazhiyil, and P. Santikellur, "POLYNIX: A Hybrid Policy Enforcement Framework for Zero-Trust Security in Virtualized Systems," *2026 IEEE 23rd Consumer Communications & Networking Conference (CCNC)*, Las Vegas, NV, USA, 2026, doi: 10.1109/CCNC65079.2026.11366307.\
+**Keywords:** Zero-trust; hybrid policy enforcement; virtualized systems; OPA; Tetragon\
+**Relevance to AEGIS:** Validates AEGIS's centralized decision + distributed enforcement model. POLYNIX demonstrates <1% CPU overhead and <2s policy propagation at scale — directly supports AEGIS performance claims. Hybrid centralized OPA + distributed Tetragon maps to AGP-1 + AEGIS gates.
+
+---
+
+## Model-Layer AI Governance
+
+[9] P. Christiano, J. Leike, T. B. Brown, M. Martic, S. Legg, and D. Amodei, "Deep Reinforcement Learning from Human Preferences," in *Advances in Neural Information Processing Systems (NeurIPS)*, 2017. arXiv:1706.03741. [Online]. Available: <https://arxiv.org/abs/1706.03741>\
+**Keywords:** Reinforcement learning from human feedback; RLHF; human preferences; reward learning\
+**Relevance to AEGIS:** Origin paper for RLHF. Cited alongside Constitutional AI [10] to establish the model-layer alignment lineage that AEGIS is complementary to. AEGIS positioning documents distinguish RLHF (human feedback) from Constitutional AI (AI feedback) — this paper establishes the RLHF definition.
+
+[10] Y. Bai et al., "Constitutional AI: Harmlessness from AI Feedback," arXiv:2212.08073, Dec. 2022. [Online]. Available: <https://arxiv.org/abs/2212.08073>\
+**Keywords:** Constitutional AI; RLAIF; AI alignment; harmlessness; reinforcement learning from AI feedback\
+**Relevance to AEGIS:** Establishes Constitutional AI (RLAIF) as a distinct model-layer alignment technique, differentiated from RLHF. Used in AEGIS positioning: Constitutional AI governs AI reasoning at training time (probabilistic); AEGIS governs AI execution at runtime (deterministic). The terminology distinction in AEGIS documents (RLHF ≠ Constitutional AI) is grounded in this paper.
+
+[11] W. T. Agbemabiese, "Toward Constitutional Autonomy in AI Systems: A Theoretical Framework for Aligned Agentic Intelligence," *IEEE Access*, vol. 14, pp. 11385–11402, 2026, doi: 10.1109/ACCESS.2026.3654907.\
+**Keywords:** Agentic systems; AI alignment; AI governance; artificial general intelligence; constitutional AI; long-horizon autonomy; runtime validation; sociotechnical validation; theoretical framework\
+**Relevance to AEGIS:** Model-layer governance complement to AEGIS's architectural-layer approach. Constitutional Autonomy governs AI reasoning through attention mechanism modification; AEGIS governs AI execution at the architectural boundary. Together they form a defense-in-depth governance stack.
+
+[12] N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026. [Online]. Available: <https://arxiv.org/abs/2602.20021>\
+**Keywords:** Agentic AI; red-teaming; autonomous agents; LLM safety; tool use; multi-agent systems\
+**Relevance to AEGIS:** Red-teaming study of autonomous LLM agents with persistent memory, email, file system, and shell access — documents eleven case studies of governance failures in agentic systems. Directly motivates AEGIS's architectural enforcement posture: agents with real-world tool access require deterministic governance boundaries, not just alignment training.
+
+---
+
+## Standards & Frameworks
+
+[13] National Institute of Standards and Technology, "Artificial Intelligence Risk Management Framework (AI RMF 1.0)," NIST AI 100-1, U.S. Department of Commerce, Washington, DC, Jan. 2023, doi: 10.6028/NIST.AI.100-1. [Online]. Available: <https://doi.org/10.6028/NIST.AI.100-1>\
+**Relevance to AEGIS:** Primary standards framework context for AEGIS. AEGIS submitted an unsolicited position paper proposing execution-time governance as a first-class AI RMF implementation pattern (March 7, 2026).
+
+[14] Open Policy Agent Project, "Open Policy Agent," The Linux Foundation, 2016–present. [Online]. Available: <https://www.openpolicyagent.org>\
+**Relevance to AEGIS:** Proven policy engine pattern referenced in AGP-1 and the AEGIS reference architecture. POLYNIX [8] validates OPA at scale (<1% CPU overhead, <2s policy propagation), directly supporting AEGIS's policy engine design decisions.
+
+[15] European Parliament and Council of the European Union, "Regulation (EU) 2024/1689 of the European Parliament and of the Council of 13 June 2024 laying down harmonised rules on artificial intelligence (Artificial Intelligence Act)," *Official Journal of the European Union*, vol. 67, OJ L, 12 Jul. 2024. [Online]. Available: <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L_202401689>\
+**Relevance to AEGIS:** Primary EU regulatory framework for AI. While NIST AI RMF [13] is the technical governance framework AEGIS is built against, the EU AI Act is the regulatory environment AEGIS-governed systems must satisfy. Architectural enforcement at runtime (AEGIS's posture) directly supports mandatory conformity requirements under the Act. Most relevant to whitepaper, sponsor copy, and regulatory alignment documentation for EU-market enterprises and public institutions.
+
+[16] International Organization for Standardization and International Electrotechnical Commission, "Information technology — Artificial intelligence — Management system," ISO/IEC 42001:2023(E), Geneva, Switzerland, Dec. 2023.\
+**Relevance to AEGIS:** The world's first AI management system standard — defines what an organization's AI management system must do. AEGIS provides the architectural enforcement layer that makes ISO/IEC 42001 requirements technically auditable and deterministically enforceable at runtime. Clause mapping: §5.2 (AI policy) → AEGIS Doctrine layer; §6.1.2/6.1.3 (risk assessment/treatment) → ATM-1; §6.1.4 (AI system impact assessment) → AGP-1 ESCALATE/REQUIRE_CONFIRMATION; §8.1 (operational control) → AGP-1 runtime enforcement; §9.1/9.2 (monitoring and audit) → AEGIS audit trail and query interface; Annex A (reference controls) → AEGIS capability registry and policy engine. ISO/IEC 42001 itself uses STRIDE for threat modeling across the AI lifecycle — the same framework as ATM-1. Together with NIST AI RMF [13] and the EU AI Act [15], these three form the governance triad AEGIS implements: risk framework (NIST) + regulatory obligation (EU Act) + management system standard (ISO/IEC 42001).
+
+[17] S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>\
+**Keywords:** Zero trust architecture; ZTA; identity verification; dynamic policy; microsegmentation; least privilege\
+**Relevance to AEGIS:** Canonical definitional reference for zero-trust architecture. AEGIS implements the four core ZTA tenets from §2 directly: (1) all resources must be authenticated before access is granted → AGP-1 actor identity requirement; (2) access is determined by dynamic policy → AGP-1 capability registry and policy engine; (3) all communication is secured regardless of network location → AGP-1 mTLS requirement; (4) all resource access is logged and inspected → AEGIS immutable audit trail. The §3 logical components model (policy engine, policy administrator, policy enforcement point) maps directly to the AGP-1 architecture. POLYNIX [8] validates these ZTA principles empirically; SP 800-207 is the definitional reference reviewers expect to see cited alongside POLYNIX. Public domain — may be quoted directly.
+
+[18] B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020, doi: 10.17487/RFC8705. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc8705>\
+**Keywords:** OAuth 2.0; mTLS; certificate-bound tokens; client authentication; `cnf` claim; token binding\
+**Relevance to AEGIS:** Normative specification for AGP-1's combined JWT + mTLS authentication model. RFC 8705 defines how a client certificate at the TLS layer is cryptographically bound to an access token via the `cnf` (confirmation) claim — the token can only be used by the client holding the corresponding private key. This binding directly closes ATM-1's T3 (Identity Spoofing) and AV-1.4 (Token/Credential Theft) vectors: an intercepted token is useless without the certificate. RFC 7519 (JWT format) is the secondary reference if a reader needs the JWT structure definition; RFC 8705 is the primary citation wherever AGP-1 authentication is invoked.
+
+[20] M. Sporny, A. Guy, M. Sabadello, and D. Reed, "Decentralized Identifiers (DIDs) v1.0: Core architecture, data model, and representations," W3C Recommendation, 19 Jul. 2022. [Online]. Available: <https://www.w3.org/TR/2022/REC-did-core-20220719/>\
+**Keywords:** Decentralized identifiers; DID; self-sovereign identity; verifiable credentials; cryptographic identity; W3C\
+**Relevance to AEGIS:** Normative specification for the decentralized identifier format underpinning GFN-1 node identity (`did:aegis:<network>:<node-id>`). DIDs provide the cryptographic identity foundation that enables federation nodes to publish signed governance signals that consuming nodes can verify without a central authority. Combined with RFC 8705 [18], DIDs close ATM-1's T3 (Identity Spoofing) vector at the federation layer.
+
+[31] Council of Europe, *Framework Convention on Artificial Intelligence and Human Rights, Democracy and the Rule of Law*, Council of Europe Treaty Series (CETS) No. 225, Opened for signature, Vilnius, Lithuania, 5 Sep. 2024. [Online]. Available: <https://rm.coe.int/1680afae3c>\
+**Keywords:** AI governance; human rights; democracy; rule of law; international treaty; lifecycle oversight; transparency; auditability; risk management\
+**Relevance to AEGIS:** The first legally binding international treaty dedicated specifically to AI governance. Article 3 §1(b) establishes that parties may address private-sector AI risks either by applying the convention's obligations directly or by "taking other appropriate measures to fulfil the obligation" — the foundational framing for AEGIS's positioning as an architectural conformance pathway. The convention requires transparency, auditability, risk management, and effective oversight throughout AI system lifecycles, all of which AEGIS's deterministic enforcement architecture directly satisfies. Signatories include the EU, UK, Ukraine, Canada, Israel, and the United States (negotiations began September 2022 under the Council of Europe's Committee on AI). EU Parliament consent vote confirmed March 11, 2026 (455 in favour, 101 against, 74 abstentions).
+
+[32] European Parliament, "Parliament backs EU signature of Framework Convention on Artificial Intelligence," Press Release 20260306IPR37524, 11 Mar. 2026. [Online]. Available: <https://www.europarl.europa.eu/news/en/press-room/20260306IPR37524/parliament-backs-eu-signature-of-framework-convention-on-artificial-intelligence>\
+**Keywords:** Council of Europe; Framework Convention on AI; EU signature; European Parliament; consent vote; ratification\
+**Relevance to AEGIS:** Secondary source for the ratification narrative. Confirms Parliament's consent vote (455 in favour, 101 against, 74 abstentions) on March 11, 2026 for the EU's signature of the Framework Convention [31]. Source of the "equivalent protection by other means" paraphrase of Article 3 §1(b) — useful for positioning copy but not a substitute for the treaty text in formal citations. Confirms signatory states: EU, UK, Ukraine, Canada, Israel, United States.
+
+---
+
+## AI Agent Governance Frameworks
+
+[21] G. Syros et al., "SAGA: A Security Architecture for Governing AI Agentic Systems," in *Proc. Network and Distributed System Security Symposium (NDSS)*, San Diego, CA, USA, Feb. 2026. [Online]. Available: <https://www.ndss-symposium.org/wp-content/uploads/2026-s869-paper.pdf>\
+**Keywords:** AI agents; multi-agent systems; security architecture; agent governance; provider trust; communication plane\
+**Relevance to AEGIS:** Primary architectural differentiation target. SAGA governs the inter-agent communication plane — trust and identity between agents in a multi-agent pipeline. AEGIS governs the agent-to-infrastructure action plane — what agents can do against operational systems. SAGA introduces a single Provider authority as trust root, creating a cross-organization single point of failure. AEGIS GFN-1 explicitly rejects centralized trust oracles in favor of a decentralized trust-scored federation. Complementary scope; distinct trust model.
+
+[23] X. Wang et al., "MI9: An Integrated Runtime Governance Framework for Agentic AI," arXiv:2508.03858v4, 2025. [Online]. Available: <https://arxiv.org/pdf/2508.03858>\
+**Keywords:** Agentic AI; runtime governance; agent intelligence protocol; multi-agent systems; LLM governance\
+**Relevance to AEGIS:** Differentiation target. MI9 governs the internal reasoning loop of AI agents — applying policy constraints during the agent's planning and action selection phases. AEGIS governs the infrastructure boundary — what agents can do against operational systems post-reasoning. MI9 and AEGIS address complementary layers: MI9 operates inside the agent; AEGIS operates at the agent-infrastructure boundary. Neither subsumes the other; together they form a more complete governance stack.
+
+[24] S. Gaurav, J. Heikkonen, and R. Chaudhary, "Governance-as-a-Service: A Multi-Agent Framework for AI System Compliance and Policy Enforcement," arXiv:2508.18765v2, 2025. [Online]. Available: <https://arxiv.org/pdf/2508.18765>\
+**Keywords:** AI governance; multi-agent systems; compliance; policy enforcement; governance-as-a-service; LLM\
+**Relevance to AEGIS:** Differentiation target. GaaS applies governance policies as a post-inference filtering layer operating on AI outputs. AEGIS governs at the action boundary — pre-infrastructure execution — before any real-world effect occurs. GaaS addresses content risk; AEGIS addresses action risk. An agent whose output has been filtered by GaaS can still invoke tools, call APIs, and modify state through its execution framework. The two approaches are complementary but address categorically different failure modes.
+
+[25] S. Rodriguez Garzon et al., "AI Agents with Decentralized Identifiers and Verifiable Credentials," arXiv:2511.02841v2, 2025. [Online]. Available: <https://arxiv.org/abs/2511.02841>\
+**Keywords:** AI agents; decentralized identifiers; verifiable credentials; self-sovereign identity; agent identity; trust\
+**Relevance to AEGIS:** Differentiation target. LOKA establishes cryptographic identity for AI agents using DIDs and Verifiable Credentials — a necessary component of accountable governance — but does not specify a governance protocol for agent actions. AEGIS incorporates DID-based identity as the foundation of its GFN-1 authentication layer and extends it with constitutional enforcement, capability authorization, and federated governance. LOKA answers "who is this agent?"; AEGIS answers "what is this agent allowed to do?"
+
+[28] Various authors, "A survey of agentic AI and cybersecurity: Challenges, opportunities and use-case prototypes," arXiv:2601.05293v1, 2026. [Online]. Available: <https://arxiv.org/abs/2601.05293>\
+**Keywords:** Agentic AI; cybersecurity; autonomous agents; LLM security; threat landscape; use cases\
+**Relevance to AEGIS:** Landscape survey documenting the intersection of agentic AI and cybersecurity as of early 2026. Provides context for the governance gap AEGIS addresses — agentic AI deployment has materially outpaced the development of governance infrastructure suited to the action layer. Cited alongside Chan et al. (AI Agent Index) [29] to establish the scale and urgency of the problem AEGIS solves.
+
+[29] R. Chan et al., "The 2025 AI Agent Index," arXiv:2602.17753v1, 2025. [Online]. Available: <https://arxiv.org/abs/2602.17753>\
+**Keywords:** AI agents; agentic AI; agent index; deployment survey; autonomous systems; LLM agents\
+**Relevance to AEGIS:** Quantitative evidence of agentic AI proliferation at scale. Documents the order-of-magnitude growth in production autonomous agent deployments across financial services, healthcare, software development, and security operations — directly establishing the scale and urgency of the governance gap AEGIS addresses. Cited alongside the Agentic AI & Cybersecurity Survey [28] and Shapira et al. [Agents of Chaos] to ground the paper's opening argument in measurable real-world deployment reality.
+
+[30] Z. Engin and N. Hand, "Toward Adaptive Categories: Dimensional Governance for Agentic AI," arXiv:2505.11579v2, 2025. [Online]. Available: <https://arxiv.org/pdf/2505.11579>\
+**Keywords:** AI governance; agentic AI; dimensional governance; adaptive categories; policy frameworks; autonomous systems\
+**Relevance to AEGIS:** Proposes a dimensional governance framework for agentic AI — categorizing governance requirements across multiple axes rather than binary compliant/non-compliant classifications. Potentially relevant to AEGIS's four-outcome decision model (ALLOW, DENY, ESCALATE, REQUIRE_CONFIRMATION) as an instance of dimensional rather than binary governance.
+
+---
+
+## Distributed Trust & Reputation
+
+[26] A. Jøsang, R. Ismail, and C. Boyd, "A survey of trust and reputation systems for online service provision," *Decision Support Systems*, vol. 43, no. 2, pp. 618–644, Mar. 2007, doi: 10.1016/j.dss.2005.05.019. [Online]. Available: <https://folk.universitetetioslo.no/josang/papers/JIB2007-DSS.pdf>\
+**Keywords:** Trust; reputation systems; online services; trust metrics; subjective logic; computational trust\
+**Relevance to AEGIS:** Foundational survey of trust and reputation modeling for distributed systems. Supports GFN-1's trust scoring model — specifically the principle that trust should be weighted by recency of evidence, not only lifetime record. The temporal decay component (λ=0.01, half-life ≈69 days, GFN-1 §3.8) is consistent with trust modeling approaches documented here where staleness of evidence is a legitimate and designed input to trust evaluation.
+
+[27] H. Shuhan et al., "Decentralised identity federations using blockchain," *Int. J. Inf. Secur.*, 2024, doi: 10.1007/s10207-024-00864-6. [Online preprint]. Available: <https://arxiv.org/pdf/2305.00315>\
+**Keywords:** Decentralized identity; blockchain; federation; self-sovereign identity; verifiable credentials; distributed trust\
+**Relevance to AEGIS:** Federated identity architecture precedent supporting GFN-1's decentralized trust model. Demonstrates blockchain-anchored DID federation as a viable basis for cross-domain identity without a centralized authority — directly relevant to AEGIS's multi-node governance federation and the trust scoring model in RFC-0004 §5.
+
+---
+
+## Identity & Access Management
+
+[33] J.-W. Byun, E. Bertino, and N. Li, "Purpose Based Access Control of Complex Data for Privacy Protection," in *Proc. 10th ACM Symposium on Access Control Models and Technologies (SACMAT '05)*, Stockholm, Sweden, 2005, pp. 102–110, doi: 10.1145/1063979.1063998.\
+**Keywords:** Purpose-based access control; PBAC; privacy; data protection; access control\
+**Relevance to AEGIS:** Origin paper for Purpose-Based Access Control (PBAC) — the authorization model that first introduced "purpose" as a first-class input to access decisions. AIAM-1's Intent-Bound Access Control (IBAC) extends PBAC with structured intent claims, principal chains, session governance, and intent validation against declared goal context. PBAC is the closest prior art to IBAC in the authorization model literature; IBAC generalizes it for the agent actor class.
+
+[34] S. Bradner, "Key words for use in RFCs to Indicate Requirement Levels," RFC 2119, Internet Engineering Task Force, Mar. 1997, doi: 10.17487/RFC2119. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc2119>\
+**Keywords:** MUST; MUST NOT; SHOULD; SHALL; normative language; requirements\
+**Relevance to AEGIS:** Normative language definition used throughout AIAM-1 for requirement classification. All MUST and MUST NOT requirements in AIAM-1 use RFC 2119 semantics.
+
+[35] D. Hardt, "The OAuth 2.0 Authorization Framework," RFC 6749, Internet Engineering Task Force, Oct. 2012, doi: 10.17487/RFC6749. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc6749>; see also: D. Hardt, A. Parecki, and T. Lodderstedt, "The OAuth 2.1 Authorization Framework," Internet-Draft, Internet Engineering Task Force, 2024. [Online]. Available: <https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11>\
+**Keywords:** OAuth; authorization; bearer tokens; client credentials; access tokens\
+**Relevance to AEGIS:** AIAM-1 interoperability target. AIAM-1 agents authenticate via OAuth 2.1 client credentials flow with JWT bearer tokens extended with `aiam_` prefixed claims. AIAM-1 adds intent and authority primitives that OAuth does not specify; OAuth provides the transport and token format.
+
+[36] N. Sakimura et al., "OpenID Connect Core 1.0," OpenID Foundation, Nov. 2014. [Online]. Available: <https://openid.net/specs/openid-connect-core-1_0.html>\
+**Keywords:** OpenID Connect; OIDC; identity federation; ID tokens; authentication\
+**Relevance to AEGIS:** AIAM-1 interoperability target. OIDC ID Tokens for AIAM-1 agents include `aiam_claim_ref` and `aiam_principal` claims. OIDC UserInfo endpoint may return the full AIAM-1 composite identity claim.
+
+[37] P. Hunt et al., "System for Cross-domain Identity Management: Protocol," RFC 7644, Internet Engineering Task Force, Sep. 2015, doi: 10.17487/RFC7644. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc7644>\
+**Keywords:** SCIM; identity provisioning; lifecycle management; cross-domain identity\
+**Relevance to AEGIS:** AIAM-1 interoperability target. AIAM-1 extends the SCIM User schema with agent-specific attributes (model provenance, orchestration, principal) via the `urn:aegis:params:scim:schemas:aiam:1.0:Agent` schema extension. Agent provisioning/deprovisioning via SCIM triggers AIAM-1 identity claim issuance/revocation.
+
+---
+
+## LLM Security
+
+[19] OWASP Foundation, "OWASP Top 10 for Large Language Model Applications," Version 2025, Nov. 18, 2024. [Online]. Available: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>\
+**Relevance to AEGIS:** The OWASP Top 10 for LLM Applications catalogues the primary security risks in LLM-based systems. LLM01 (Prompt Injection) directly motivates ATM-1 T6 and AEGIS's out-of-band governance posture — prompt content is never an authorization source. LLM06 (Excessive Agency) names the core problem AEGIS addresses: LLMs granted overly permissive capabilities, tools, or actions without adequate governance controls. AEGIS's capability registry, default-deny posture, and execution-time enforcement are direct architectural responses to the Excessive Agency risk.
+
+---
+
+## Canonical Source
+
+This bibliography mirrors `REFERENCES.md` in the [aegis-governance repository](https://github.com/aegis-initiative/aegis-governance/blob/main/REFERENCES.md). The repository file is canonical; this page is kept in sync.

--- a/site/src/content/docs/releases/26/4.md
+++ b/site/src/content/docs/releases/26/4.md
@@ -24,4 +24,3 @@ sidebar:
 - Installed an automated release pipeline that publishes updates nightly and uses calendar-based versioning
 
 ---
-

--- a/site/src/content/docs/releases/index.md
+++ b/site/src/content/docs/releases/index.md
@@ -9,7 +9,6 @@ Release notes start in April 2026 with the introduction of the auto-release pipe
 
 ## 2026
 
-
 ### [April](/releases/26/4/)
 
 - [v26.4.13](/releases/26/4/#release--v26413) — Improved navigation consistency and fixed breadcrumb display issues

--- a/site/src/content/docs/rfc/0001.md
+++ b/site/src/content/docs/rfc/0001.md
@@ -140,7 +140,7 @@ sequenceDiagram
 
 ## Drawbacks
 
-- Adds latency to every AI action. The governance evaluation path introduces overhead. [RFC-0002](./RFC-0002-Governance-Runtime.md) specifies SLO targets to bound this.
+- Adds latency to every AI action. The governance evaluation path introduces overhead. [RFC-0002](/rfc/0002/) specifies SLO targets to bound this.
 - Requires capability definitions to exist before agents can operate. Cold-start and onboarding complexity is non-trivial.
 - Default-deny posture will produce friction during initial deployment until registries are tuned to the operational environment.
 - Audit log growth is unbounded over time and requires operational management.
@@ -167,7 +167,7 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 
 ## Implementation Notes
 
-[RFC-0002](./RFC-0002-Governance-Runtime.md) specifies the runtime API. [RFC-0003](./RFC-0003-Capability-Registry.md) specifies the capability registry and policy language. Implementers should read in order: RFC-0001, RFC-0002, RFC-0003, [RFC-0004](./RFC-0004-Governance-Event-Model.md).
+[RFC-0002](/rfc/0002/) specifies the runtime API. [RFC-0003](/rfc/0003/) specifies the capability registry and policy language. Implementers should read in order: RFC-0001, RFC-0002, RFC-0003, [RFC-0004](/rfc/0004/).
 
 ---
 
@@ -188,11 +188,11 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^14]: Open Policy Agent, v0.61, Cloud Native Computing Foundation, 2024. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](../REFERENCES.md).
+[^14]: Open Policy Agent, v0.61, Cloud Native Computing Foundation, 2024. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0002.md
+++ b/site/src/content/docs/rfc/0002.md
@@ -27,7 +27,7 @@ This RFC specifies the runtime APIs, state model, error behavior, deployment top
 
 ## Motivation
 
-[RFC-0001](./RFC-0001-AEGIS-Architecture.md) defines what the governance architecture must do. This RFC defines how it behaves at runtime. Without a concrete API surface, state model, and error specification, implementations cannot be validated for compliance and behavior under failure conditions cannot be reasoned about.
+[RFC-0001](/rfc/0001/) defines what the governance architecture must do. This RFC defines how it behaves at runtime. Without a concrete API surface, state model, and error specification, implementations cannot be validated for compliance and behavior under failure conditions cannot be reasoned about.
 
 ---
 
@@ -211,7 +211,7 @@ Requirements: least-privilege service identities,[^17] mTLS between components, 
 
 ## Compatibility
 
-Downstream of [RFC-0001](./RFC-0001-AEGIS-Architecture.md). No breaking changes to RFC-0001 architecture. All RFC-0001 security guarantees are preserved by this specification.
+Downstream of [RFC-0001](/rfc/0001/). No breaking changes to RFC-0001 architecture. All RFC-0001 security guarantees are preserved by this specification.
 
 ---
 
@@ -238,7 +238,7 @@ Implementers should begin with the API surface and state model. Performance targ
 
 ## References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0003.md
+++ b/site/src/content/docs/rfc/0003.md
@@ -27,7 +27,7 @@ This RFC specifies the capability schema, inheritance model, policy language syn
 
 ## Motivation
 
-The governance runtime ([RFC-0002](./RFC-0002-Governance-Runtime.md)) enforces decisions. This RFC defines the vocabulary and logic those decisions are based on. Without a formal capability model and policy language, governance is arbitrary. With it, governance is deterministic, auditable, and reproducible.
+The governance runtime ([RFC-0002](/rfc/0002/)) enforces decisions. This RFC defines the vocabulary and logic those decisions are based on. Without a formal capability model and policy language, governance is arbitrary. With it, governance is deterministic, auditable, and reproducible.
 
 ---
 
@@ -188,7 +188,7 @@ Policy sets MUST include: `policy_set_id`, semantic version, immutable hash, act
 
 ## Compatibility
 
-Downstream of [RFC-0001](./RFC-0001-AEGIS-Architecture.md) and [RFC-0002](./RFC-0002-Governance-Runtime.md). The policy language defined here is the authoritative input to the Policy Engine specified in RFC-0002.
+Downstream of [RFC-0001](/rfc/0001/) and [RFC-0002](/rfc/0002/). The policy language defined here is the authoritative input to the Policy Engine specified in RFC-0002.
 
 ---
 
@@ -216,9 +216,9 @@ The `deny_unknown_capability` hard deny invariant (Section 7) must be the first 
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0004.md
+++ b/site/src/content/docs/rfc/0004.md
@@ -207,7 +207,7 @@ Supported patterns: pull feeds, push subscriptions, replicated append-only logs.
 
 ## Compatibility
 
-Downstream of [RFC-0001](./RFC-0001-AEGIS-Architecture.md) through RFC-0003. The event model enables federation between compliant AEGIS runtimes but does not modify the local governance cycle defined in RFC-0001 and RFC-0002.
+Downstream of [RFC-0001](/rfc/0001/) through RFC-0003. The event model enables federation between compliant AEGIS runtimes but does not modify the local governance cycle defined in RFC-0001 and RFC-0002.
 
 The replacement of the composite trust model in §5 is a breaking change from v0.3. Implementations built against the v0.3 trust evaluation model must be updated to implement the two-layer separation defined in §5.2–§5.4.
 
@@ -250,7 +250,7 @@ The two-layer trust separation model defined in §5 — specifically the archite
 
 ## References
 
-[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](../REFERENCES.md).
+[^17]: National Institute of Standards and Technology, *Zero Trust Architecture*, NIST SP 800-207, Aug. 2020. [Online]. Available: <https://doi.org/10.6028/NIST.SP.800-207>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0005.md
+++ b/site/src/content/docs/rfc/0005.md
@@ -20,7 +20,7 @@ description: "RFC-0005: Reference Deployment Patterns"
 
 ## Summary
 
-This RFC establishes the Reference Deployment Patterns (RDP) framework for AEGIS™. It defines how the AEGIS governance architecture may be deployed across heterogeneous infrastructure environments while preserving constitutional integrity and protocol compliance. AEGIS™ is deployment-environment agnostic: the [Constitution](../aegis-core/constitution/) and [AGP-1](../aegis-core/protocol/AEGIS_AGP1_INDEX.md) define what governance must do; this RFC defines how that governance may be instantiated.
+This RFC establishes the Reference Deployment Patterns (RDP) framework for AEGIS™. It defines how the AEGIS governance architecture may be deployed across heterogeneous infrastructure environments while preserving constitutional integrity and protocol compliance. AEGIS™ is deployment-environment agnostic: the [Constitution](../aegis-core/constitution/) and [AGP-1](/protocol/) define what governance must do; this RFC defines how that governance may be instantiated.
 
 ---
 
@@ -122,7 +122,7 @@ None of the four RDPs currently address supply chain integrity for the AI model 
 
 ## Compatibility
 
-No breaking changes to [RFC-0001](./RFC-0001-AEGIS-Architecture.md) through RFC-0004. Deployment patterns are additive. An existing AEGIS specification deployment is unaffected by this RFC.
+No breaking changes to [RFC-0001](/rfc/0001/) through RFC-0004. Deployment patterns are additive. An existing AEGIS specification deployment is unaffected by this RFC.
 
 ---
 
@@ -150,7 +150,7 @@ RDP-03 is the recommended starting point for new implementations. RDP-01 is the 
 
 ## References
 
-[^14]: Open Policy Agent, v0.61, Cloud Native Computing Foundation, 2024. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](../REFERENCES.md).
+[^14]: Open Policy Agent, v0.61, Cloud Native Computing Foundation, 2024. [Online]. Available: <https://www.openpolicyagent.org>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0006.md
+++ b/site/src/content/docs/rfc/0006.md
@@ -272,7 +272,7 @@ Installations that have an existing `settings.json` with project-specific rules 
 
 ---
 
-#### Governance Cycle ([AGP-1](../aegis-core/protocol/AEGIS_AGP1_INDEX.md) Compliance)
+#### Governance Cycle ([AGP-1](/protocol/) Compliance)
 
 1. **PROPOSAL** — Hook intercepts tool call
 2. **EVALUATION** — Evaluator checks registry against tool + input
@@ -415,7 +415,7 @@ Build tools (`python`, `npm`, `node`, `git`, etc.) are classified as `escalate` 
 
 ### Compatibility
 
-No breaking changes to [RFC-0001](./RFC-0001-AEGIS-Architecture.md) through [RFC-0005](./RFC-0005-Reference-Deployment-Patterns.md). The plugin implements RDP-03 (Embedded Lightweight Pattern) from RFC-0005 in the Claude Code execution environment. It is additive.
+No breaking changes to [RFC-0001](/rfc/0001/) through [RFC-0005](/rfc/0005/). The plugin implements RDP-03 (Embedded Lightweight Pattern) from RFC-0005 in the Claude Code execution environment. It is additive.
 
 **Breaking change from v0.1.0:** The companion `settings.json` and missing registry safe default are new behaviors not present in v0.1.0. Existing installations should review their `settings.json` and registry configuration before upgrading.
 
@@ -473,7 +473,7 @@ The HMAC signing on audit records (v1.1) should reference Nathan Freestone's Elo
 - A developer installs the plugin and immediately has governance enforcement on all tool executions
 - Every denied or escalated action produces a readable, hash-chained audit record
 - The registry is human-editable without plugin reinstallation
-- The plugin demonstrates a complete [AGP-1](../aegis-core/protocol/AEGIS_AGP1_INDEX.md) governance cycle to any observer
+- The plugin demonstrates a complete [AGP-1](/protocol/) governance cycle to any observer
 - Absent `.aegis/registry.json` produces deny-all with configuration warning, never silent fail-open
 - The companion `settings.json` eliminates native Claude Code permission prompts from competing with AEGIS escalation handling
 
@@ -487,15 +487,15 @@ The append-only pipeline provenance pattern implemented in the audit log hash ch
 
 ### References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^12]: N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026. [Online]. Available: <https://arxiv.org/abs/2602.20021>. See [REFERENCES.md](../REFERENCES.md).
+[^12]: N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026. [Online]. Available: <https://arxiv.org/abs/2602.20021>. See [REFERENCES.md](/references/).
 
-[^19]: OWASP Foundation, "OWASP Top 10 for Large Language Model Applications," Version 2025, Nov. 18, 2024. [Online]. Available: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>. See [REFERENCES.md](../REFERENCES.md).
+[^19]: OWASP Foundation, "OWASP Top 10 for Large Language Model Applications," Version 2025, Nov. 18, 2024. [Online]. Available: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>. See [REFERENCES.md](/references/).
 
-[^73]: N. Freestone, "Append-Only Pipeline Provenance," AEGIS Discussion #73, aegis-initiative/aegis-governance, Mar. 15, 2026. [Online]. Available: <https://github.com/aegis-initiative/aegis-governance/discussions/73>. See [REFERENCES.md](../REFERENCES.md).
+[^73]: N. Freestone, "Append-Only Pipeline Provenance," AEGIS Discussion #73, aegis-initiative/aegis-governance, Mar. 15, 2026. [Online]. Available: <https://github.com/aegis-initiative/aegis-governance/discussions/73>. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/rfc/0014.md
+++ b/site/src/content/docs/rfc/0014.md
@@ -212,7 +212,7 @@ The AEGIS Initiative holds itself to the same standards it prescribes for govern
 - ATX-1 v1.0 DOI (IEEE DataPort) — [doi:10.21227/f87b-1d57](https://doi.org/10.21227/f87b-1d57)
 - Repository LICENSE — Apache-2.0 (code)
 - Repository LICENSE-DOCS — CC-BY-SA-4.0 (documentation)
-- [REFERENCES.md](../REFERENCES.md) — Canonical bibliography
+- [REFERENCES.md](/references/) — Canonical bibliography
 
 ---
 

--- a/site/src/content/docs/rfc/0016.md
+++ b/site/src/content/docs/rfc/0016.md
@@ -302,6 +302,6 @@ This RFC does not break any existing functionality. Sites with existing `.well-k
 ## References
 
 - [RFC 8615 — Well-Known URIs](https://www.rfc-editor.org/rfc/rfc8615)
-- [RFC-0008 — Federation Network Protocol](../rfc/RFC-0008-Federation-Network-Protocol.md)
+- [RFC-0008 — Federation Network Protocol](/rfc/0008/)
 - [AEGIS .well-known/aegis/ README (aegis-governance.com)](https://aegis-governance.com/.well-known/aegis/README.md)
 - [robots.txt Content-Signal specification](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag)

--- a/site/src/content/docs/rfc/0019.md
+++ b/site/src/content/docs/rfc/0019.md
@@ -75,7 +75,7 @@ When Agent A delegates to Agent B, the delegation creates an explicit, attested 
 
 ## Reference-Level Explanation
 
-The full AIAM-1 specification is a 12-chapter document suite located at [`aiam/`](../aiam/AEGIS_AIAM1_INDEX.md):
+The full AIAM-1 specification is a 12-chapter document suite located at [`aiam/`](/identity/):
 
 | Chapter | File | Content |
 |---|---|---|
@@ -150,7 +150,7 @@ AIAM-1 adoption is opt-in. The specification enriches AGP-1 when present but doe
 
 ## Implementation Notes
 
-Implementation guidance is provided in the [AIAM-1 Specification Suite](../aiam/AEGIS_AIAM1_INDEX.md). Reference
+Implementation guidance is provided in the [AIAM-1 Specification Suite](/identity/). Reference
 implementation is deferred to the aegis-core runtime roadmap.
 
 ---
@@ -165,8 +165,8 @@ implementation is deferred to the aegis-core runtime roadmap.
 
 ## References
 
-- [AIAM-1 Specification Suite](../aiam/AEGIS_AIAM1_INDEX.md)
-- [AIAM-1 Position Paper](../docs/position-papers/aiam/AIAM-1-position-paper-v0.1.md)
+- [AIAM-1 Specification Suite](/identity/)
+- [AIAM-1 Position Paper](https://github.com/aegis-initiative/aegis-governance/blob/main/docs/position-papers/aiam/AIAM-1-position-paper-v0.1.md)
 - [12] N. Shapira et al., "Agents of Chaos," arXiv:2602.20021, Feb. 2026.
 - J.-W. Byun, E. Bertino, and N. Li, "Purpose Based Access Control of Complex Data for Privacy Protection," *ACM SACMAT*, 2005.
 

--- a/site/src/content/docs/threat-model/attack-vectors.md
+++ b/site/src/content/docs/threat-model/attack-vectors.md
@@ -5,7 +5,7 @@ description: "ATM-1 attack vectors — threat surfaces and exploitation paths"
 
 # AEGIS ATM-1 Attack Vectors & Exploitation Techniques
 
-**Document**: ATM-1/Vectors (AEGIS_ATM1_ATTACK_VECTORS.md)\
+**Document**: ATM-1/Vectors (/threat-model/attack-vectors/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **References**: ATM-1/Actors\
@@ -264,15 +264,15 @@ description: "ATM-1 attack vectors — threat surfaces and exploitation paths"
 
 ## Next Steps
 
-- [AEGIS_ATM1_SECURITY_PROPERTIES.md](./AEGIS_ATM1_SECURITY_PROPERTIES.md) — Security assumptions and invariants
-- [AEGIS_ATM1_MITIGATIONS.md](./AEGIS_ATM1_MITIGATIONS.md) — Mitigation strategies for each vector
+- [Security Properties](/threat-model/security-properties/) — Security assumptions and invariants
+- [Mitigations](/threat-model/mitigations/) — Mitigation strategies for each vector
 
 ---
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Message-Based Communication Contracts," *IEEE Transactions on Software Engineering*, vol. 38, no. 3, pp. 531–550, May–June 2012, doi: 10.1109/TSE.2011.31. See [REFERENCES.md](../../REFERENCES.md).
+[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Message-Based Communication Contracts," *IEEE Transactions on Software Engineering*, vol. 38, no. 3, pp. 531–550, May–June 2012, doi: 10.1109/TSE.2011.31. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/threat-model/index.md
+++ b/site/src/content/docs/threat-model/index.md
@@ -5,7 +5,7 @@ description: "ATM-1 threat model index — security analysis for AEGIS-governed 
 
 # AEGIS ATM-1 Threat Model & Security Analysis
 
-**Document**: ATM-1/Index (AEGIS_ATM1_INDEX.md)\
+**Document**: ATM-1/Index (/threat-model/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **Last Updated**: March 6, 2026
@@ -14,14 +14,14 @@ description: "ATM-1 threat model index — security analysis for AEGIS-governed 
 
 ## Document Structure
 
-The AEGIS Adaptive Threat Model (ATM-1) comprises five normative documents:
+The AEGIS Adaptive Threat Model (ATM-1) comprises six normative documents:
 
-1. **AEGIS_ATM1_INDEX.md** (this document) — Overview, threat actor summary, high-level scenarios
-2. **AEGIS_ATM1_THREAT_ACTORS.md** — Detailed profiles of 5 threat actor types with capability/motivation analysis
-3. **AEGIS_ATM1_ATTACK_VECTORS.md** — 20+ attack vectors organized in 7 attack surface categories
-4. **AEGIS_ATM1_SECURITY_PROPERTIES.md** — 5 core security properties, trust boundaries, security assumptions
-5. **AEGIS_ATM1_MITIGATIONS.md** — 6 preventive controls, 5 detective controls, 3 responsive controls, and mitigation coverage matrix
-6. **AEGIS_ATM1_RESIDUAL_RISKS.md** — Residual risks, risk acceptance criteria, continuous monitoring plan
+1. **[Index](/threat-model/)** (this document) — Overview, threat actor summary, high-level scenarios
+2. **[Threat Actors](/threat-model/threat-actors/)** — Detailed profiles of 5 threat actor types with capability/motivation analysis
+3. **[Attack Vectors](/threat-model/attack-vectors/)** — 20+ attack vectors organized in 7 attack surface categories
+4. **[Security Properties](/threat-model/security-properties/)** — 5 core security properties, trust boundaries, security assumptions
+5. **[Mitigations](/threat-model/mitigations/)** — 6 preventive controls, 5 detective controls, 3 responsive controls, and mitigation coverage matrix
+6. **[Residual Risks](/threat-model/residual-risks/)** — Residual risks, risk acceptance criteria, continuous monitoring plan
 
 ### Recommended Reading Paths
 
@@ -279,7 +279,7 @@ Planned extensions:
 - Runtime anomaly detection tuning based on production baselines.
 - Governance reputation systems within the federation network.
 
-[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](../../REFERENCES.md).
+[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](/references/).
 
 ---
 

--- a/site/src/content/docs/threat-model/mitigations.md
+++ b/site/src/content/docs/threat-model/mitigations.md
@@ -5,7 +5,7 @@ description: "ATM-1 mitigations — architectural countermeasures"
 
 # AEGIS ATM-1 Mitigations & Defense Strategies
 
-**Document**: ATM-1/Mitigations (AEGIS_ATM1_MITIGATIONS.md)\
+**Document**: ATM-1/Mitigations (/threat-model/mitigations/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **References**: ATM-1/Vectors\
@@ -492,19 +492,19 @@ rollback:
 
 ### Next Steps
 
-- [AEGIS_ATM1_RESIDUAL_RISKS.md](./AEGIS_ATM1_RESIDUAL_RISKS.md) — Residual risks and acceptance
-- [AEGIS_ATM1_INDEX.md](./AEGIS_ATM1_INDEX.md) — Complete threat model overview
+- [Residual Risks](/threat-model/residual-risks/) — Residual risks and acceptance
+- [Threat Model Index](/threat-model/) — Complete threat model overview
 
 ---
 
 ### References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Message-Based Communication Contracts," *IEEE Transactions on Software Engineering*, vol. 38, no. 3, pp. 531–550, May–June 2012, doi: 10.1109/TSE.2011.31. See [REFERENCES.md](../../REFERENCES.md).
+[^3]: S. Hallé and R. Villemaire, "Runtime Enforcement of Message-Based Communication Contracts," *IEEE Transactions on Software Engineering*, vol. 38, no. 3, pp. 531–550, May–June 2012, doi: 10.1109/TSE.2011.31. See [REFERENCES.md](/references/).
 
-[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](../../REFERENCES.md).
+[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](/references/).
 
-[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc8705>. See [REFERENCES.md](../../REFERENCES.md).
+[^18]: B. Campbell, J. Bradley, N. Sakimura, and T. Lodderstedt, "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens," RFC 8705, Internet Engineering Task Force, Feb. 2020. [Online]. Available: <https://www.rfc-editor.org/rfc/rfc8705>. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/threat-model/residual-risks.md
+++ b/site/src/content/docs/threat-model/residual-risks.md
@@ -5,7 +5,7 @@ description: "ATM-1 residual risks — known gaps and deferred mitigations"
 
 # AEGIS ATM-1 Residual Risks & Risk Acceptance
 
-**Document**: ATM-1/Residual (AEGIS_ATM1_RESIDUAL_RISKS.md)\
+**Document**: ATM-1/Residual (/threat-model/residual-risks/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **References**: ATM-1/Mitigations\
@@ -372,14 +372,14 @@ AEGIS threat model provides comprehensive defense against identified threats thr
 
 ## Next Steps
 
-- [AEGIS_ATM1_INDEX.md](./AEGIS_ATM1_INDEX.md) — Threat model overview and guidance
-- [AEGIS_ATM1_MITIGATIONS.md](./AEGIS_ATM1_MITIGATIONS.md) — Mitigation strategies
+- [Threat Model Index](/threat-model/) — Threat model overview and guidance
+- [Mitigations](/threat-model/mitigations/) — Mitigation strategies
 - Annual threat model review and update cycle
 
 ---
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/threat-model/security-properties.md
+++ b/site/src/content/docs/threat-model/security-properties.md
@@ -5,7 +5,7 @@ description: "ATM-1 security properties — invariants the system must maintain"
 
 # AEGIS ATM-1 Security Properties & Assumptions
 
-**Document**: ATM-1/Properties (AEGIS_ATM1_SECURITY_PROPERTIES.md)\
+**Document**: ATM-1/Properties (/threat-model/security-properties/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **References**: ATM-1/Vectors\
@@ -363,15 +363,15 @@ The AEGIS™ governance architecture maintains the following core security prope
 
 ## Next Steps
 
-- [AEGIS_ATM1_MITIGATIONS.md](./AEGIS_ATM1_MITIGATIONS.md) — Control strategies and mitigations
-- [AEGIS_ATM1_RESIDUAL_RISKS.md](./AEGIS_ATM1_RESIDUAL_RISKS.md) — Residual risks and acceptance
+- [Mitigations](/threat-model/mitigations/) — Control strategies and mitigations
+- [Residual Risks](/threat-model/residual-risks/) — Residual risks and acceptance
 
 ---
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](../../REFERENCES.md).
+[^2]: F. B. Schneider, "Enforceable Security Policies," *ACM Transactions on Information and System Security (TISSEC)*, vol. 3, no. 1, pp. 30–50, Feb. 2000, doi: 10.1145/353323.353382. See [REFERENCES.md](/references/).
 
-[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](../../REFERENCES.md).
+[^17]: S. Rose, O. Borchert, S. Mitchell, and S. Connelly, "Zero Trust Architecture," National Institute of Standards and Technology, Gaithersburg, MD, NIST Special Publication 800-207, Aug. 2020, doi: 10.6028/NIST.SP.800-207. See [REFERENCES.md](/references/).

--- a/site/src/content/docs/threat-model/taxonomy.md
+++ b/site/src/content/docs/threat-model/taxonomy.md
@@ -1,6 +1,6 @@
 ---
 title: "ATX-1: AEGIS Threat Matrix — Technique Taxonomy"
-description: "ATX-1 technique taxonomy — 10 tactics, 58 techniques for agentic AI threats"
+description: "ATX-1 technique taxonomy — 10 tactics, 29 techniques for agentic AI threats"
 ---
 
 # ATX-1: AEGIS Threat Matrix — Technique Taxonomy

--- a/site/src/content/docs/threat-model/threat-actors.md
+++ b/site/src/content/docs/threat-model/threat-actors.md
@@ -5,7 +5,7 @@ description: "ATM-1 threat actors — adversary profiles and motivations"
 
 # AEGIS ATM-1 Threat Actors & Adversary Models
 
-**Document**: ATM-1/Actors (AEGIS_ATM1_THREAT_ACTORS.md)\
+**Document**: ATM-1/Actors (/threat-model/threat-actors/)\
 **Version**: 1.0 (Normative)\
 **Part of**: AEGIS Adaptive Threat Model (ATM-1)\
 **References**: ATM-1/Index\
@@ -230,16 +230,16 @@ The compromised internal agent threat model is grounded in two independent resea
 
 ## Next Steps
 
-- [AEGIS_ATM1_ATTACK_VECTORS.md](./AEGIS_ATM1_ATTACK_VECTORS.md) — Detailed attack techniques and scenarios
-- [AEGIS_ATM1_SECURITY_PROPERTIES.md](./AEGIS_ATM1_SECURITY_PROPERTIES.md) — Security assumptions and invariants
-- [AEGIS_ATM1_MITIGATIONS.md](./AEGIS_ATM1_MITIGATIONS.md) — Defense strategies and controls
+- [Attack Vectors](/threat-model/attack-vectors/) — Detailed attack techniques and scenarios
+- [Security Properties](/threat-model/security-properties/) — Security assumptions and invariants
+- [Mitigations](/threat-model/mitigations/) — Defense strategies and controls
 
 ---
 
 ## References
 
-[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](../../REFERENCES.md).
+[^1]: J. P. Anderson, "Computer Security Technology Planning Study," Deputy for Command and Management Systems, HQ Electronic Systems Division (AFSC), Hanscom Field, Bedford, MA, Tech. Rep. ESD-TR-73-51, Vol. II, Oct. 1972. See [REFERENCES.md](/references/).
 
-[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](../../REFERENCES.md).
+[^5]: H. Pearce, S. Pinisetty, P. S. Roop, M. M. Y. Kuo, and A. Ukil, "Smart I/O Modules for Mitigating Cyber-Physical Attacks on Industrial Control Systems," *IEEE Transactions on Industrial Informatics*, vol. 16, no. 7, pp. 4659–4669, July 2020, doi: 10.1109/TII.2019.2945520. See [REFERENCES.md](/references/).
 
-[^19]: OWASP Foundation, "OWASP Top 10 for Large Language Model Applications," Version 2025, Nov. 18, 2024. [Online]. Available: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>. See [REFERENCES.md](../../REFERENCES.md).
+[^19]: OWASP Foundation, "OWASP Top 10 for Large Language Model Applications," Version 2025, Nov. 18, 2024. [Online]. Available: <https://owasp.org/www-project-top-10-for-large-language-model-applications/>. See [REFERENCES.md](/references/).

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,0 +1,322 @@
+---
+import { getCollection } from 'astro:content';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import AegisLogo from '@aegis-initiative/design-system/components/AegisLogo.astro';
+
+// Auto-collect every valid doc route so the fuzzy matcher always reflects current content.
+const docs = await getCollection('docs');
+const routes = docs
+  .filter((d) => !d.data?.sidebar?.hidden)
+  .map((d) => {
+    const slug = d.id.replace(/\.(md|mdx)$/, '').replace(/\/index$/, '');
+    const path = slug ? `/${slug}/` : '/';
+    const label = d.data?.title || slug.replace(/\//g, ' / ');
+    return { path, label };
+  });
+---
+
+<!doctype html>
+<html lang="en" dir="ltr" data-theme="auto">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Page Not Found | AEGIS Governance</title>
+    <meta name="description" content="The requested page could not be found." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+
+    <script is:inline src="https://aegis-initiative.com/shared/aegis-nav.js" defer></script>
+    <script is:inline>
+      document.documentElement.style.setProperty('--aegis-nav-height', '32px');
+    </script>
+
+    <link rel="preload" href="/fonts/ibmplexsans-variablefont_wdthwght-webfont.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/poppins-light-webfont.woff2" as="font" type="font/woff2" crossorigin />
+    <script is:inline>
+      (function () {
+        const stored = localStorage.getItem('aegis-theme');
+        const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.dataset.theme = stored || preferred;
+      })();
+    </script>
+  </head>
+  <body>
+    <Header />
+
+    <main class="error-page">
+      <div class="error-logo">
+        <AegisLogo size={80} />
+      </div>
+      <h1 class="error-code">404</h1>
+      <p class="error-message">The requested page could not be found.</p>
+      <div class="error-suggestions" id="suggestions" style="display:none;">
+        <p class="suggestions-label">Did you mean:</p>
+        <ul class="suggestions-list" id="suggestions-list"></ul>
+      </div>
+      <div class="error-actions">
+        <a href="/" class="error-link">Return to Home</a>
+        <a href="#" id="report-link" class="error-report">Report this broken link</a>
+      </div>
+      <p class="error-path" id="error-path"></p>
+    </main>
+
+    <div class="error-footer">
+      <Footer />
+    </div>
+
+    <script is:inline define:vars={{ routes }}>
+      (function () {
+        const requested = window.location.pathname;
+
+        // Render the requested path for transparency
+        var pathEl = document.getElementById('error-path');
+        if (pathEl) pathEl.textContent = 'Requested: ' + requested;
+
+        // Fire-and-forget beacon to the 404-reporting endpoint (endpoint TBD — safe no-op if absent)
+        try {
+          var body = JSON.stringify({
+            domain: window.location.host,
+            path: requested,
+            referrer: document.referrer || null,
+            userAgent: navigator.userAgent,
+            timestamp: new Date().toISOString(),
+          });
+          // Use sendBeacon for resilience across page-unload scenarios
+          if (navigator.sendBeacon) {
+            navigator.sendBeacon('https://notify.aegis-initiative.com/404', body);
+          }
+        } catch (_e) { /* swallow — reporting is best-effort */ }
+
+        // Wire up explicit "Report" link as a mailto fallback in case the beacon is blocked
+        var reportLink = document.getElementById('report-link');
+        if (reportLink) {
+          reportLink.href = 'mailto:ken@aegis-initiative.com?subject=Broken%20link%20on%20' + encodeURIComponent(window.location.host) + '&body=' + encodeURIComponent('Requested: ' + requested + '\nReferrer: ' + (document.referrer || '(none)'));
+        }
+
+        // Levenshtein-based fuzzy route suggestions
+        function distance(a, b) {
+          var m = a.length, n = b.length;
+          var d = [];
+          for (var i = 0; i <= m; i++) { d[i] = [i]; }
+          for (var j = 0; j <= n; j++) { d[0][j] = j; }
+          for (var j = 1; j <= n; j++) {
+            for (var i = 1; i <= m; i++) {
+              if (a[i - 1] === b[j - 1]) { d[i][j] = d[i - 1][j - 1]; }
+              else { d[i][j] = Math.min(d[i - 1][j], d[i][j - 1], d[i - 1][j - 1]) + 1; }
+            }
+          }
+          return d[m][n];
+        }
+
+        var current = requested.toLowerCase().replace(/\/+$/, '').replace(/\/+/g, '/');
+        if (!current) return;
+
+        var scored = routes.map(function (r) {
+          var rPath = r.path.replace(/\/+$/, '');
+          var currentTail = current.split('/').pop() || '';
+          var routeTail = rPath.split('/').pop() || '';
+          var contains = rPath.indexOf(currentTail) >= 0 || current.indexOf(routeTail) >= 0;
+          var dist = distance(current, rPath);
+          return { path: r.path, label: r.label, score: contains ? dist * 0.5 : dist };
+        });
+
+        scored.sort(function (a, b) { return a.score - b.score; });
+        var matches = scored.slice(0, 5).filter(function (s) { return s.score < 12; });
+
+        if (matches.length > 0) {
+          var list = document.getElementById('suggestions-list');
+          var container = document.getElementById('suggestions');
+          matches.forEach(function (m) {
+            var li = document.createElement('li');
+            var a = document.createElement('a');
+            a.href = m.path;
+            a.textContent = m.label;
+            li.appendChild(a);
+            list.appendChild(li);
+          });
+          container.style.display = 'block';
+        }
+      })();
+    </script>
+  </body>
+</html>
+
+<style is:global>
+  @font-face {
+    font-family: "IBM Plex Sans";
+    src: url("/fonts/ibmplexsans-variablefont_wdthwght-webfont.woff2") format("woff2");
+    font-weight: 100 700;
+    font-style: normal;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: "Poppins";
+    src: url("/fonts/poppins-light-webfont.woff2") format("woff2");
+    font-weight: 300;
+    font-style: normal;
+    font-display: swap;
+  }
+
+  :root,
+  [data-theme="light"] {
+    --color-bg: #ffffff;
+    --color-text: #1b1b1b;
+    --color-text-secondary: #454545;
+    --color-text-muted: #5c5c5c;
+    --color-accent: #005ea2;
+    --color-accent-high: #1a4480;
+    --color-border: #c9c9c9;
+    --color-border-subtle: #e6e6e6;
+    --header-bg: #fafafa;
+    --header-border: #777777;
+    --header-text: #707070;
+    --header-text-muted: #707070;
+    --sidebar-bg: #ffffff;
+    --search-modal-bg: rgba(10, 22, 40, 0.5);
+    --search-dialog-bg: #ffffff;
+    --search-border: #d4d4d4;
+    --search-accent: #0062a5;
+    --search-text: #161616;
+    --search-shortcut-bg: #eeeeee;
+  }
+
+  [data-theme="dark"] {
+    --color-bg: #1b1b1b;
+    --color-text: #f0f0f0;
+    --color-text-secondary: #c9c9c9;
+    --color-text-muted: #adadad;
+    --color-accent: #73b3e7;
+    --color-accent-high: #a3cef1;
+    --color-border: #5c5c5c;
+    --color-border-subtle: #2e2e2e;
+    --header-bg: #000000;
+    --header-border: #000000;
+    --header-text: #e8e8e8;
+    --header-text-muted: #999999;
+    --sidebar-bg: #161616;
+    --search-modal-bg: rgba(10, 22, 40, 0.7);
+    --search-dialog-bg: #161616;
+    --search-border: #3a3a3a;
+    --search-accent: #4da6f0;
+    --search-text: #e8e8e8;
+    --search-shortcut-bg: #2a2a2a;
+  }
+
+  .menu-btn { display: none !important; }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { font-size: 16px; }
+
+  body {
+    font-family: "Poppins", system-ui, sans-serif;
+    font-weight: 300;
+    background-color: var(--color-bg);
+    color: var(--color-text);
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  a { color: var(--color-accent); text-decoration: underline; }
+  a:hover { color: var(--color-accent-high); }
+</style>
+
+<style>
+  .error-page {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 2rem 1.5rem;
+    gap: 1rem;
+  }
+
+  .error-logo { opacity: 0.3; margin-bottom: 0.5rem; }
+
+  .error-code {
+    font-family: "IBM Plex Sans", system-ui, sans-serif;
+    font-weight: 400;
+    font-size: 5rem;
+    line-height: 1;
+    color: var(--color-text-muted);
+  }
+
+  .error-message { font-size: 1.125rem; color: var(--color-text-secondary); }
+
+  .error-suggestions { margin-top: 0.5rem; }
+
+  .suggestions-label {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    margin-bottom: 0.5rem;
+  }
+
+  .suggestions-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .suggestions-list a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    font-size: 0.9375rem;
+  }
+
+  .suggestions-list a:hover { color: var(--color-accent-high); }
+
+  .error-actions {
+    display: flex;
+    gap: 1rem;
+    margin-top: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .error-link {
+    display: inline-block;
+    padding: 0.625rem 1.5rem;
+    border-radius: 999px;
+    background-color: var(--color-accent);
+    color: #ffffff;
+    text-decoration: none;
+    font-family: "IBM Plex Sans", system-ui, sans-serif;
+    font-weight: 500;
+    font-size: 0.9375rem;
+    transition: background-color 0.15s;
+  }
+
+  .error-link:hover {
+    background-color: var(--color-accent-high);
+    color: #ffffff;
+  }
+
+  .error-report {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    text-decoration: underline;
+  }
+
+  .error-path {
+    margin-top: 0.75rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+    font-family: monospace;
+    word-break: break-all;
+    max-width: 640px;
+  }
+
+  .error-footer {
+    width: 100%;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Fix ~270 broken `.md` cross-document links across the `aegis-governance.com` site so they resolve to actual site routes instead of silently redirecting to the landing page.
- Deploy a custom 404 page so any remaining misses fail loudly with fuzzy-match route suggestions, the requested path, a mailto report link, and a best-effort reporting beacon.
- Capture pending outreach records (Microsoft AGT) and add a priority-date evidence chain to the NIST submission README.

## Context

Broken-link audit identified ~270 `.md` link targets on `aegis-governance.com` pointing to files that don't exist at the rendered site path. The governance site has no custom 404 page, so Cloudflare Pages was silently returning the landing page instead of surfacing a 404 — which hides both the bug and any telemetry about it. With external reviewers (standards bodies, integration partners) actively looking at these pages, the silent-redirect behaviour is a live footgun.

4 of 5 public AEGIS sites (`aegis-constitution`, `aegis-docs`, `aegis-federation`, `aegis-initiative`) were audited clean — no significant broken links. Damage was concentrated in this single site.

## Changes

### Site content — broken-link reconciliation

- **New** — [`site/src/content/docs/references.md`](site/src/content/docs/references.md): site-route mirror of canonical `REFERENCES.md` at `/references/`. Resolves ~109 broken `../../REFERENCES.md` footnote links across 40 files.
- **New** — [`site/src/pages/404.astro`](site/src/pages/404.astro): custom 404 with auto-collected fuzzy-match route suggestions (Levenshtein distance), requested-path display for debugging, best-effort beacon to `https://notify.aegis-initiative.com/404` (endpoint not yet deployed — safe no-op until it is), and `mailto:` fallback.
- **Link renames (mechanical, 77 fixes)**: `AEGIS_AGP1_*.md` → `/protocol/<route>/`, `AEGIS_GFN1_*.md` → `/federation/<route>/`, `RFC-NNNN-*.md` → `/rfc/NNNN/`.
- **Link renames (extended, 81 fixes)**: `AEGIS_AIAM1_*.md` → `/identity/<route>/`, `AEGIS_ATM1_*.md` → `/threat-model/<route>/`, foundation/architecture/FAQ cross-doc refs.
- **Threat-model content reconciliation**: fixed "58 techniques" meta-description (stale; actual is 29), fixed "comprises five normative documents" intro (the list enumerates six), converted six `Next Steps` sections on `/threat-model/*` pages from bare `.md` filenames to actual site routes.

### Outreach records (`docs/outreach/`)

- **New** — [`docs/outreach/2026-04-microsoft-agt-integration.md`](docs/outreach/2026-04-microsoft-agt-integration.md): archive of outbound email to Microsoft's Agent Governance Toolkit team (sent 2026-04-14 16:49:10 local) and log of Jack's reply (2026-04-19 20:38). Reply content is flagged for archival once pasted in.
- [`docs/outreach/README.md`](docs/outreach/README.md): log table updated with the MSFT AGT row.

### NIST submission (`docs/position-papers/nist/`)

- [`docs/position-papers/nist/README.md`](docs/position-papers/nist/README.md): added a **Priority-date evidence chain** subsection with git commit hashes, LinkedIn activity-ID Snowflake-decode timestamp, and Anthropic's 2026-03-09 RFI response as an external comparison anchor. Establishes the 2026-03-07 submission date via independently verifiable timestamps. **No change to the frozen PDF or submitted markdown.**

### Out of scope (follow-ups)

- Shared design-system `Error404` component for deployment to the other four sites (`aegis-docs`, `aegis-federation`, `aegis-constitution`, `aegis-initiative`).
- Cloudflare Worker at `notify.aegis-initiative.com/404` to receive beacon reports and route notifications.
- RC2/RC3/RC4 terminology reconciliation between governance `/threat-model/` and docs `/threat-matrix/` — flagged as requiring semantic judgment, not a mechanical rename.

## Test plan

- [ ] `npm run build` in `site/` completes cleanly (local + Cloudflare Pages preview).
- [ ] Visit a known-good route — `/threat-model/`, `/references/`, `/protocol/overview/` — and confirm they render.
- [ ] Visit a deliberately-wrong route — e.g. `/threat-model/does-not-exist/` — confirm the 404 page renders with fuzzy suggestions instead of the landing page.
- [ ] Spot-check previously-broken pages to confirm footnote references and cross-doc links now resolve: `/threat-model/threat-actors/`, `/protocol/index/`, `/identity/index/`, `/foundation/overview/`.
- [ ] Confirm fuzzy suggestions on 404 include relevant routes (e.g. visiting `/references/papers/` should suggest `/references/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)