### PR TITLE
chore(seo): advertise sitemap-index.xml in robots.txt

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -9,3 +9,5 @@ Allow: /
 # Specification docs: 73 pages across /foundation/, /architecture/, /protocol/,
 #   /threat-model/, /identity/, /federation/, /rfc/
 # Data downloads: /data/, /atx-1/, /schemas/
+
+Sitemap: https://aegis-governance.com/sitemap-index.xml


### PR DESCRIPTION
## Summary
\`@astrojs/sitemap\` is already wired up and produces \`/sitemap-index.xml\` at build time, but \`robots.txt\` didn't reference it. Add the \`Sitemap:\` line so crawlers find it without having to guess.

## Test plan
- [ ] After deploy: verify \`https://aegis-governance.com/robots.txt\` shows the new \`Sitemap:\` line
- [ ] After deploy: submit sitemap in Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)