### PR TITLE
feat(seo): add ecosystem sameAs and enable Labs in cross-site nav

### DIFF
--- a/site/public/shared/aegis-nav.js
+++ b/site/public/shared/aegis-nav.js
@@ -19,7 +19,7 @@
     { id: 'governance',   label: 'Governance',   domain: 'aegis-governance.com',   url: 'https://aegis-governance.com',   visible: true },
     { id: 'docs',         label: 'Docs',         domain: 'aegis-docs.com',         url: 'https://aegis-docs.com',         visible: true },
     { id: 'federation',   label: 'Federation',   domain: 'aegis-federation.com',   url: 'https://aegis-federation.com',   visible: true },
-    { id: 'labs',         label: 'Labs',         domain: 'aegis-labs.dev',         url: 'https://aegis-labs.dev',         visible: false },
+    { id: 'labs',         label: 'Labs',         domain: 'aegis-labs.dev',         url: 'https://aegis-labs.dev',         visible: true },
     { id: 'sdk',          label: 'SDK',          domain: 'aegis-sdk.dev',          url: 'https://aegis-sdk.dev',          visible: false },
     { id: 'platform',     label: 'Platform',     domain: 'aegis-platform.net',     url: 'https://aegis-platform.net',     visible: false },
   ];

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -64,6 +64,25 @@ import AegisWordmark from '@aegis-initiative/design-system/components/AegisWordm
     }
   }
   </script>
+
+  <!-- Organization + ecosystem sameAs (cross-site SEO signal) -->
+  <script is:inline type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "AEGIS Initiative",
+    "url": "https://aegis-initiative.com",
+    "sameAs": [
+      "https://aegis-initiative.com",
+      "https://aegis-constitution.com",
+      "https://aegis-governance.com",
+      "https://aegis-docs.com",
+      "https://aegis-federation.com",
+      "https://aegis-labs.dev",
+      "https://github.com/aegis-initiative"
+    ]
+  }
+  </script>
 </head>
 <body>
   <Header />


### PR DESCRIPTION
## Summary

- Add a top-level `Organization` JSON-LD entry with the canonical `sameAs` array (initiative + constitution + governance + docs + federation + labs.dev + GitHub) so Google treats all 6 AEGIS sites as one entity cluster.
- Flip `aegis-labs.dev` to `visible: true` in the shared cross-site nav bar (`public/shared/aegis-nav.js`), now that Labs has a public landing site.

This matches the PRs already merged across the other 5 ecosystem repos (initiative, constitution, docs, federation, labs).

## Test plan

- [ ] After deploy, paste `https://aegis-governance.com` into Google's Rich Results Test and confirm the new `Organization` block parses with the full `sameAs` array
- [ ] Visually confirm the cross-site nav bar shows **Labs** as a visible peer link

🤖 Generated with [Claude Code](https://claude.com/claude-code)