### PR TITLE
docs: release notes for 2026-05-16

### DIFF
--- a/site/VERSION
+++ b/site/VERSION
@@ -1,5 +1,5 @@
 {
-  "tag": "v26.5.14",
-  "commit": "d39065d",
-  "released_at": "2026-05-15T06:12:01Z"
+  "tag": "v26.5.16",
+  "commit": "63edf5e",
+  "released_at": "2026-05-17T06:04:55Z"
 }

--- a/site/src/content/docs/releases/26/5.md
+++ b/site/src/content/docs/releases/26/5.md
@@ -6,6 +6,15 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.5.16
+
+*Builds: c258ac3 – 63edf5e* — [Development Log →](/releases/26/5/16/)
+
+- Fixed formatting in the release index by removing extra blank lines
+- Cleaned up Markdown linting and spelling issues across documentation
+
+---
+
 ## Release / v26.5.14
 
 *Builds: 76b7912 – d39065d* — [Development Log →](/releases/26/5/14/)

--- a/site/src/content/docs/releases/26/5/16.md
+++ b/site/src/content/docs/releases/26/5/16.md
@@ -9,3 +9,4 @@ sidebar:
 ## Development Log
 
 - fix(releases): collapse double blank lines in release index (MD012) (c258ac3)
+- fix(lint): clear pre-existing markdownlint and spellcheck failures on main (5bfa24e)

--- a/site/src/content/docs/releases/26/5/16.md
+++ b/site/src/content/docs/releases/26/5/16.md
@@ -1,0 +1,11 @@
+---
+title: "May 16, 2026"
+description: "Development log for May 16, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+- fix(releases): collapse double blank lines in release index (MD012) (c258ac3)

--- a/site/src/content/docs/releases/26/5/16.md
+++ b/site/src/content/docs/releases/26/5/16.md
@@ -10,3 +10,4 @@ sidebar:
 
 - fix(releases): collapse double blank lines in release index (MD012) (c258ac3)
 - fix(lint): clear pre-existing markdownlint and spellcheck failures on main (5bfa24e)
+- chore(spell): allow Cemri, Reprompt, IDEsaster in cspell dictionary (63edf5e)

--- a/site/src/content/docs/releases/26/5/16.md
+++ b/site/src/content/docs/releases/26/5/16.md
@@ -6,6 +6,14 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.5.16
+
+*Builds: c258ac3 – 63edf5e*
+
+- Fixed formatting in the release index by removing extra blank lines
+- Cleaned up Markdown linting and spelling issues across documentation
+
+---
 ## Development Log
 
 - fix(releases): collapse double blank lines in release index (MD012) (c258ac3)

--- a/site/src/content/docs/releases/index.md
+++ b/site/src/content/docs/releases/index.md
@@ -11,6 +11,7 @@ Release notes start in April 2026 with the introduction of the auto-release pipe
 
 ### [May](/releases/26/5/)
 
+- [v26.5.16](/releases/26/5/#release--v26516) — Fixed release index formatting and documentation linting issues
 - [v26.5.14](/releases/26/5/#release--v26514) — ATX-1 v2.3 manuscript revision with external validation and IEEE DataPort release
 - [v26.5.13](/releases/26/5/#release--v26513) — ATX-1 v2.3 taxonomy published with official DOI on Zenodo
 - [v26.5.9](/releases/26/5/#release--v2659) — Added ecosystem identity links and enabled Labs in navigation


### PR DESCRIPTION
Daily release rollup — dev log, monthly summary, and index update for 2026-05-16.