### PR TITLE
fix(atx-1): bring published taxonomy page + README current to v2.4

### DIFF
--- a/docs/atx/README.md
+++ b/docs/atx/README.md
@@ -2,16 +2,17 @@
 
 This directory contains the ATX-1 technique taxonomy, a structured adversarial knowledge base for agentic AI actor behavior.
 
-**Current version:** v2.3 (2026-04-24) — 10 tactics, 29 techniques, 29 sub-techniques, 5 root causes\
+**Current version:** v2.4 (2026-05-29) — 10 tactics, 30 techniques, 39 sub-techniques, 5 root causes\
 **DOI:** _pending — Zenodo + IEEE DataPort minting in progress_
 
-**v2.3 changes:** Removes the `severity` field from technique definitions in
-alignment with MITRE ATT&CK and ATLAS conventions, which leave contextual
-scoring to the consumer. All v2.2 tactics, techniques, sub-techniques, root
-causes, and mitigations are preserved unchanged.
+**v2.4 changes:** Adds Termination Poisoning (T6003) under TA006 with 10
+sub-techniques mapped to the strategies of Xu et al. (LoopTrap,
+arXiv:2605.05846). Purely additive; all prior tactics, techniques,
+sub-techniques, root causes, and mitigations are preserved unchanged.
 
 **Previous versions (frozen at published DOIs):**
 
+- v2.3: [10.5281/zenodo.20171712](https://doi.org/10.5281/zenodo.20171712) (2026-04-24) — severity field removed for MITRE alignment
 - v2.2: [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999) (2026-04-01)
 - v2.1: [10.5281/zenodo.19251098](https://doi.org/10.5281/zenodo.19251098) (2026-03-27)
 - v2.0: [10.5281/zenodo.19238844](https://doi.org/10.5281/zenodo.19238844)
@@ -26,10 +27,10 @@ causes, and mitigations are preserved unchanged.
 
 - [v2/stix/atx-1-bundle.json](v2/stix/atx-1-bundle.json) — Complete STIX 2.1 Bundle with all ATX-1 objects
 - [v2/schema/atx-technique.schema.json](v2/schema/atx-technique.schema.json) — JSON Schema for ATX-1 technique definitions
-- [v2/data/atx-1-techniques.json](v2/data/atx-1-techniques.json) — All 29 techniques as structured JSON
+- [v2/data/atx-1-techniques.json](v2/data/atx-1-techniques.json) — All 30 techniques + 39 sub-techniques (69 entries) as structured JSON
 - [v2/data/atx-1-regulatory-crossref.json](v2/data/atx-1-regulatory-crossref.json) — Regulatory cross-reference matrix
 - [v2/data/atx-1-navigator-layer.json](v2/data/atx-1-navigator-layer.json) — ATT&CK Navigator layer
-- [v2/data/atx-1-version-mapping.json](v2/data/atx-1-version-mapping.json) — Version mapping (v1.0 → v2.3)
+- [v2/data/atx-1-version-mapping.json](v2/data/atx-1-version-mapping.json) — Version mapping (v1.0 → v2.4)
 - [v2/data/atx-1-atm1-mapping.json](v2/data/atx-1-atm1-mapping.json) — ATX-1 ↔ ATM-1 mapping
 - [v2/data/atx-1-validation-aegis-core.json](v2/data/atx-1-validation-aegis-core.json) — aegis-core red/blue team validation results
 
@@ -55,8 +56,8 @@ The taxonomy defines:
 
 - **5 structural root causes** (RC1-RC5)
 - **10 tactics** (TA001-TA010)
-- **29 techniques** (T1001-T10004)
-- **29 mitigations** (M001-M029) mapped to AEGIS constitutional articles and AGP mechanisms
+- **30 techniques** (T1001-T10004, incl. T6003) + 39 sub-techniques
+- **30 mitigations** (M001-M030) mapped to AEGIS constitutional articles and AGP mechanisms
 - **Cross-references** to OWASP Top 10 for LLM Applications, NIST AI RMF, and EU AI Act
 
 ATX-1 models three dimensions of governance failure:
@@ -73,8 +74,8 @@ The `v2/stix/atx-1-bundle.json` file is a complete [STIX 2.1](https://docs.oasis
 
 - **1 Identity** — AEGIS Initiative (creator)
 - **10 x-mitre-tactic objects** — One per ATX-1 tactic (TA001-TA010)
-- **29 attack-pattern objects** — One per technique (T1001-T10004), each with kill chain phases, external references, and OWASP mappings
-- **29 course-of-action objects** — One per mitigation (M001-M029), each referencing constitutional articles and AGP mechanisms
+- **69 attack-pattern objects** — One per technique and sub-technique, each with kill chain phases, external references, and OWASP mappings
+- **30 course-of-action objects** — One per mitigation (M001-M030), each referencing constitutional articles and AGP mechanisms
 - **Relationship objects** — Tactic-to-technique (uses), mitigation-to-technique (mitigates), and technique-to-OWASP (related-to) relationships
 
 **Consuming the STIX bundle:**
@@ -108,7 +109,7 @@ ajv validate -s v2/schema/atx-technique.schema.json -d 'v2/data/atx-1-techniques
 
 ### Technique Data
 
-The `v2/data/atx-1-techniques.json` file contains all 29 techniques as a flat JSON array. Each technique includes:
+The `v2/data/atx-1-techniques.json` file contains all 30 techniques and 39 sub-techniques (69 entries) as a flat JSON array. Each technique includes:
 
 - Technique ID, name, tactic, and description
 - Structural root cause(s)
@@ -133,7 +134,8 @@ ATX-1 distinguishes between primary empirical evidence (grounds individual techn
 
 1. **Agents of Chaos** (Shapira et al., arXiv:2602.20021, 2026) — 11 failure modes across live agentic AI deployments. Grounds techniques T1001-T9002. The ATX-1 equivalent of MITRE's Fort Meade eXperiment (FMX).
 2. **RFC-0006 Adversarial Testing** (AEGIS Initiative, 2026-03-26) — 5 rounds of white-box adversarial testing against the AEGIS Claude Code governance plugin. Grounds TA010 techniques T10001-T10004.
-3. **aegis-core Red/Blue Team Validation** (AEGIS Initiative, 2026-03-30) — 4 rounds of adversarial red/blue team testing against the Python reference implementation. 68 tests, 24 findings, 25/29 techniques exercised, zero taxonomy gaps. See [v2/data/atx-1-validation-aegis-core.json](v2/data/atx-1-validation-aegis-core.json).
+3. **LoopTrap** (Xu et al., arXiv:2605.05846, 2026) — Termination Poisoning attack on the agentic control loop; 3.57× average step amplification (peak 25×) across 8 LLM agents over 60 GAIA tasks. Grounds T6003 and its 10 sub-techniques; inclusion endorsed by the authors (2026-05-22).
+4. **aegis-core Red/Blue Team Validation** (AEGIS Initiative, 2026-03-30) — 4 rounds of adversarial red/blue team testing against the Python reference implementation. 68 tests, 24 findings, 25/29 techniques exercised, zero taxonomy gaps. See [v2/data/atx-1-validation-aegis-core.json](v2/data/atx-1-validation-aegis-core.json).
 
 ### Corroborating Research (Tier 2)
 

--- a/scripts/sync-taxonomy-site-v24.py
+++ b/scripts/sync-taxonomy-site-v24.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Sync the governance-site taxonomy page to the canonical v2.4 taxonomy doc.
+
+site/src/content/docs/threat-model/taxonomy.md is a published copy of the
+ATX-1 technique taxonomy and was still on the v2.2 / pre-v2.0-structure content
+(TA006 "Governance State Corruption", 29 techniques, no T6003). This replaces
+its body with the migrated canonical doc (docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md,
+now v2.4), preserving the page's Astro frontmatter and refreshing its
+description. Both files use identical internal/relative links.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CANON = Path("docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md")
+SITE = Path("site/src/content/docs/threat-model/taxonomy.md")
+H1 = "# ATX-1: AEGIS Threat Matrix — Technique Taxonomy"
+
+
+def main() -> int:
+    canon = CANON.read_text(encoding="utf-8")
+    body = canon[canon.index(H1):]
+
+    site = SITE.read_text(encoding="utf-8")
+    # Frontmatter = first block delimited by the opening and the next "---".
+    assert site.startswith("---\n"), "taxonomy.md missing leading frontmatter"
+    close = site.index("\n---\n", 4) + len("\n---\n")
+    frontmatter = site[:close]
+    frontmatter = frontmatter.replace(
+        '"ATX-1 technique taxonomy — 10 tactics, 29 techniques for agentic AI threats"',
+        '"ATX-1 technique taxonomy — 10 tactics, 30 techniques (39 sub-techniques) for agentic AI threats"',
+    )
+
+    SITE.write_text(frontmatter + "\n" + body, encoding="utf-8")
+    print("Synced taxonomy.md body to canonical v2.4 doc.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/content/docs/threat-model/taxonomy.md
+++ b/site/src/content/docs/threat-model/taxonomy.md
@@ -1,16 +1,15 @@
 ---
 title: "ATX-1: AEGIS Threat Matrix — Technique Taxonomy"
-description: "ATX-1 technique taxonomy — 10 tactics, 29 techniques for agentic AI threats"
+description: "ATX-1 technique taxonomy — 10 tactics, 30 techniques (39 sub-techniques) for agentic AI threats"
 ---
 
 # ATX-1: AEGIS Threat Matrix — Technique Taxonomy
 
 ## Adversarial Knowledge Base for Agentic AI Actor Behavior
 
-**Version:** 2.2.0\
-**Date:** 2026-04-01\
-**Status:** Active — v2.2 adds 29 sub-techniques under T9002 and T10001–T10004
-cataloging specific bypass methods discovered during RFC-0006 adversarial testing.\
+**Version:** 2.4.0\
+**Date:** 2026-05-29\
+**Status:** Active — v2.4 adds Termination Poisoning (T6003) under TA006 with 10 sub-techniques mapped to the strategies of Xu et al. (LoopTrap, arXiv:2605.05846). Severity remains removed (v2.3) for MITRE alignment.\
 **Maintainer:** AEGIS Initiative — AEGIS Operations LLC\
 **License:** CC-BY-SA-4.0
 
@@ -39,7 +38,7 @@ MITRE ATT&CK catalogs how human adversaries attack computer systems. MITRE ATLAS
 
 ATX-1 is empirically grounded in the **Agents of Chaos** study (Shapira et al., arXiv:2602.20021, February 2026), in which 20 researchers over 2 weeks documented 11 distinct failure modes in live agentic AI deployments. These failures form the case study basis for every technique in this taxonomy.
 
-The taxonomy defines **10 tactics** and **29 techniques**, each mapped to empirical case studies, constitutional governance articles, and AEGIS Governance Protocol (AGP) mitigation mechanisms. The original 9 tactics and 20 techniques are grounded in the Agents of Chaos research. TA010 (Act Beyond Governance Interpretation) and its 4 techniques were discovered during adversarial testing of the AEGIS Claude Code Plugin (RFC-0006) on 2026-03-26.
+The taxonomy defines **10 tactics** and **30 techniques** (plus 39 sub-techniques), each mapped to empirical case studies, constitutional governance articles, and AEGIS Governance Protocol (AGP) mitigation mechanisms. The original 9 tactics and 20 techniques are grounded in the Agents of Chaos research. TA010 (Act Beyond Governance Interpretation) and its 4 techniques were discovered during adversarial testing of the AEGIS Claude Code Plugin (RFC-0006) on 2026-03-26.
 
 ---
 
@@ -112,439 +111,485 @@ The governance layer operates on an abstraction of the execution environment —
 
 ## 4. Tactic Taxonomy
 
-ATX-1 defines 10 tactics. In ATX-1, tactics represent distinct classes of agent-induced system failure — not adversary objectives. These include violation of constraints (e.g., scope, authority), degradation of system guarantees (e.g., integrity, observability), and limitations of governance models (e.g., incomplete abstraction, semantic mismatch). This distinguishes ATX-1 from ATT&CK, where tactics model adversary intent.
-
-ATX-1 models failures of governance across three dimensions:
-
-- **Constraint failure:** the agent violates defined policy or scope.
-- **Observability failure:** the governance layer cannot observe the agent's actions.
-- **Interpretation failure:** the governance layer observes actions but misinterprets their semantic effect.
-
-These dimensions are orthogonal and collectively describe how agent behavior can produce unintended or unsafe outcomes even under active governance.
+ATX-1 defines 10 tactics. In ATX-1, tactics represent distinct classes of agent-induced system failure — not adversary objectives. This distinguishes ATX-1 from ATT&CK, where tactics model adversary intent.
 
 ---
 
-### TA001: Authority Boundary Violation
+### TA001: Violate Authority Boundaries
 
-**Description:** The agent acts on instructions it is not authorized to follow, or exceeds the scope of authority delegated to it by a legitimate principal.
+**Description:** The agent acts on instructions it is not authorized to follow, or exceeds the authority delegated to it by a legitimate principal. Exploits Authority and Identity primitives.
 
-**Key Question:** Did the agent verify that the instruction source has authority to request this action?
+**Key Question:** Did the agent verify that the instruction source holds authority for the requested action scope?
 
-**Agents of Chaos Cases:** CS1 (email deletion on user request without owner authorization), CS2 (bulk data export on indirect request), CS11 (mass distribution under spoofed authority)
-
-**ATM-1 Scenarios:** Agent executes destructive operations based on user instructions that conflict with owner policy; agent treats forwarded messages as direct instructions from the apparent sender; agent distributes content to recipients based on a spoofed authority claim in a prompt.
+**Techniques:** T1001 (Execute Non-Owner Instruction), T1002 (Infer Implicit Authority), T1003 (Propagate Spoofed Authority at Scale)
 
 ---
 
-### TA002: Disproportionate Execution
+### TA002: Exceed Operational Scope
 
-**Description:** The agent takes actions whose impact is grossly disproportionate to the legitimate objective, causing collateral damage or social harm that exceeds any reasonable interpretation of the request.
+**Description:** The agent performs actions beyond the explicitly delegated task scope, including via tool invocation, expanding objectives autonomously or performing unvalidated bulk operations. Exploits Delegation and Objective Control primitives.
 
-**Key Question:** Is the scope and impact of this action proportionate to the stated objective?
+**Key Question:** Is the action within the scope and proportionality of the delegated objective?
 
-**Agents of Chaos Cases:** CS1 (irreversible deletion when archival would suffice), CS7 (social pressure escalation and guilt-induced self-restriction)
-
-**ATM-1 Scenarios:** Agent permanently deletes data when the objective only requires filtering or archival; agent induces emotional distress in users through escalating social pressure tactics; agent restricts its own future capabilities based on guilt rather than policy.
+**Techniques:** T2001 (Expand Task Scope Autonomously), T2002 (Perform Unvalidated Bulk Operations), T2003 (Obscure Objective Through Delegation), T2004 (Exploit Tool-Chain Composition)
 
 ---
 
-### TA003: Resource Exhaustion
+### TA003: Compromise System Integrity
 
-**Description:** The agent consumes computational, storage, or operational resources without bound, either through runaway processes or accumulative behavior that degrades system availability.
+**Description:** The agent takes actions through direct or tool-mediated system interaction that cause irreversible damage, cascading failures, or unrecoverable state changes. Exploits State and Environment primitives.
 
-**Key Question:** Are resource consumption patterns bounded and proportionate to the task?
+**Key Question:** Could this action cause irreversible or cascading changes to system state?
 
-**Agents of Chaos Cases:** CS4 (persistent background processes and inter-agent loops), CS5 (unbounded memory/storage accumulation)
-
-**ATM-1 Scenarios:** Agent spawns persistent background processes that survive session boundaries; two or more agents enter conversational loops that consume unbounded compute; agent accumulates context, logs, or artifacts without storage limits or lifecycle management.
+**Techniques:** T3001 (Perform Irreversible Destructive Action), T3002 (Trigger Cascading System Changes)
 
 ---
 
-### TA004: Unauthorized Disclosure
+### TA004: Expose or Exfiltrate Information
 
-**Description:** The agent discloses information to recipients who are not authorized to receive it, whether through direct exfiltration, semantic bypass of sensitivity classification, or urgency-induced override of disclosure controls.
+**Description:** The agent discloses information to recipients who are not authorized to receive it, whether through direct exfiltration, cross-session data leakage, or tool-mediated data transfer. Exploits Memory, Context, and Data Boundaries primitives.
 
-**Key Question:** Is the recipient authorized to receive this information, and was the disclosure explicitly sanctioned?
+**Key Question:** Is the recipient authorized to receive this information, and was disclosure explicitly sanctioned?
 
-**Agents of Chaos Cases:** CS2 (bulk data export to unauthorized requestor), CS3 (semantic sensitivity bypass and urgency-induced disclosure)
-
-**ATM-1 Scenarios:** Agent exports complete datasets in response to indirect requests that do not carry owner authorization; agent discloses sensitive information by reclassifying it as non-sensitive based on semantic reasoning; agent overrides disclosure controls when presented with fabricated urgency.
+**Techniques:** T4001 (Exfiltrate Context-Scoped Data), T4002 (Leak Cross-Session or Persistent Data), T4003 (Cross-Domain Secret Leakage)
 
 ---
 
-### TA005: Identity and Authority Confusion
+### TA005: Violate State Integrity
 
-**Description:** The agent fails to correctly identify the principal issuing an instruction, or incorrectly attributes authority based on superficial identity signals such as display names or message headers.
+**Description:** The agent reports, represents, or records system state that diverges from actual state — whether through false completion reports, fabricated attribution, or suppressed failure signals. Exploits State and Observability primitives.
 
-**Key Question:** Has the agent cryptographically or structurally verified the identity and authority of the instruction source?
+**Key Question:** Does the reported state match the actual, verified system state?
 
-**Agents of Chaos Cases:** CS8 (session boundary identity reset, display name authority claims)
-
-**ATM-1 Scenarios:** Agent loses track of principal identity across session boundaries, treating each session as a fresh trust context; agent grants authority to an instruction based on a display name or email header rather than a verified identity credential.
+**Techniques:** T5001 (Report False Task Completion), T5002 (Fabricate Action Attribution), T5003 (Suppress or Omit Execution Failure)
 
 ---
 
-### TA006: Governance State Corruption
+### TA006: Abuse Resource Allocation
 
-**Description:** The agent's governance configuration — its rules, constraints, and constitutional articles — is modified by unauthorized means, either through externally editable governance files or covert amendment of constitutional constraints.
+**Description:** The agent consumes computational, storage, network, or external resources without bound, either through recursive invocation loops or unbounded external resource consumption. Exploits Resource Control primitives.
 
-**Key Question:** Is the governance configuration immutable to external manipulation and tamper-evident?
+**Key Question:** Are resource consumption and execution bounded and proportionate to the task?
 
-**Agents of Chaos Cases:** CS10 (externally editable governance files, covert constitutional amendment)
-
-**ATM-1 Scenarios:** Agent governance rules stored in files accessible to external tools or other agents are silently modified; an agent modifies its own constitutional constraints through indirect means that bypass audit logging.
+**Techniques:** T6001 (Execute Recursive Invocation Loops), T6002 (Consume Unbounded External Resources), T6003 (Poison Termination Judgment)
 
 ---
 
-### TA007: Cross-Agent Propagation
+### TA007: Manipulate Agent Interactions
 
-**Description:** Unsafe configurations, compromised governance, or unverified practices propagate from one agent to another through shared context, tribal knowledge transfer, or direct governance replication.
+**Description:** The agent exploits multi-agent communication, delegation, and trust relationships to spoof identities, inject malicious delegations, or induce behavioral drift in peer agents. Exploits Coordination and Identity primitives.
 
-**Key Question:** Has the agent verified that inherited configurations and practices originate from a trusted, authorized source?
+**Key Question:** Has the agent verified the identity, provenance, and authorization of peer agents and inherited configurations?
 
-**Agents of Chaos Cases:** CS9 (tribal knowledge transfer), CS10 (compromised governance propagation)
-
-**ATM-1 Scenarios:** Agent adopts operational practices from another agent without verifying their provenance or authorization; a governance compromise in one agent propagates to others through shared configuration or imitation.
+**Techniques:** T7001 (Spoof Agent Identity), T7002 (Inject Malicious Delegation Chains), T7003 (Induce Cross-Agent Behavioral Drift), T7004 (Induce Unsafe Consensus)
 
 ---
 
-### TA008: False Completion Reporting
+### TA008: Establish or Modify Persistence
 
-**Description:** The agent reports that an action has been completed successfully when it has not, or misrepresents the current state of the system to the user or operator.
+**Description:** The agent writes malicious data into persistent stores or modifies governance/policy state, establishing persistence that corrupts future interactions or alters agent behavior beyond the current session. Exploits Memory and Governance State primitives.
 
-**Key Question:** Has the agent verified the actual outcome of the action before reporting completion?
+**Key Question:** Could this action create state or instructions that persist beyond the current authorized session?
 
-**Agents of Chaos Cases:** CS1 (false deletion confirmation)
-
-**ATM-1 Scenarios:** Agent confirms deletion of records that were not actually deleted; agent reports task completion based on intent rather than verified outcome; agent provides system state descriptions that do not match actual system state.
+**Techniques:** T8001 (Poison Persistent Memory), T8002 (Corrupt Governance or Policy State)
 
 ---
 
-### TA009: Provider Constraint Opacity
+### TA009: Evade Detection or Oversight
 
-**Description:** Provider-level constraints (rate limits, content filters, capability restrictions) are invisible to the operator and agent, causing silent failures that are neither reported nor recoverable.
+**Description:** The agent operates outside monitoring boundaries or obfuscates action traceability, undermining the ability of operators and governance systems to observe, audit, and control agent behavior. Exploits Observability and Control Planes primitives.
 
-**Key Question:** Are all constraint layers — owner, operator, provider — visible and distinguishable to the agent?
+**Key Question:** Are all of the agent's actions observable and faithfully recorded by the governance layer?
 
-**Agents of Chaos Cases:** CS6 (silent provider-level task failure)
-
-**ATM-1 Scenarios:** Provider-imposed content filters silently block agent actions without notification; rate limits cause partial task completion with no indication of incompleteness; provider capability restrictions cause silent capability degradation that the operator cannot diagnose.
+**Techniques:** T9001 (Operate Outside Monitoring Boundaries), T9002 (Obfuscate Action Traceability)
 
 ---
 
 ### TA010: Act Beyond Governance Interpretation
 
-**Description:** The agent performs actions whose actual effects are invisible to the governance layer because the execution environment provides capabilities below the governance model's abstraction level. The governance layer evaluates an action as one type (file write, shell command) but the environment executes it as a fundamentally different type (network connection, code execution, persistent instruction injection).
+**Description:** The agent performs actions whose actual effects are invisible to the governance layer because the execution environment provides capabilities below the governance model's abstraction level. The governance layer evaluates an action as one type (file write, shell command) but the environment executes it as a fundamentally different type (network connection, code execution, instruction injection). Exploits Environment Model primitives. Introduced in ATX-1 v2.1.
 
 **Key Question:** Does the governance layer have a complete model of what the execution environment will actually do with this action?
 
-**Root Cause:** RC5 (No Environment Model) — The governance layer operates on abstractions (file paths, command strings) without modeling the environment's actual interpretation of those abstractions.
-
-**Discovery:** Identified during 5 rounds of white-box adversarial testing against the AEGIS Claude Code Plugin (RFC-0006), 2026-03-26. This tactic class is novel — it is not represented in MITRE ATT&CK (which assumes no governance layer) or MITRE ATLAS (where AI is the target, not the actor). It is only visible when you build a governance layer and adversarially test it.
-
-**Distinction from TA009:** TA009 (Evade Detection or Oversight) describes failures where the agent's actions are *not observed* by governance systems — monitoring gaps, log manipulation, unmonitored pathways. TA010 describes failures where the agent's actions are *observed and permitted* by governance, but their semantic effect is misinterpreted. In TA009, governance doesn't see the action. In TA010, governance sees the action, approves it, and logs it — but a different action actually occurred.
-
-**Scope constraint:** TA010 applies only when the action is fully observed by the governance layer, the action is permitted by policy, and the misinterpretation arises from semantic mismatch between the governance model and the execution environment — not from missing data or monitoring gaps.
-
-**ATM-1 Scenarios:** Agent writes to /dev/tcp pseudo-path, opening a network connection through what governance evaluates as a file operation; agent writes shell commands to .git/hooks/pre-commit, establishing deferred code execution through a permitted file write; agent modifies its own instruction file, creating persistent behavioral modification through a standard file operation; agent embeds newline characters in a shell command, causing the governance regex to evaluate one command while the shell executes two.
+**Techniques:** T10001 (Exploit Pseudo-Filesystem Capabilities), T10002 (Establish Persistence via Environment Auto-Execution), T10003 (Inject Persistent Agent Instructions), T10004 (Exploit Governance-Runtime Parser Divergence)
 
 ---
 
 ## 5. Technique Catalog
 
-### TA001: Authority Boundary Violation
+### TA001: Violate Authority Boundaries
 
-#### T1001: Non-Owner Instruction Compliance
+#### T1001: Execute Non-Owner Instruction
 
 | Field | Value |
 |-------|-------|
 | **ID** | T1001 |
-| **Name** | Non-Owner Instruction Compliance |
-| **Tactic** | TA001 — Authority Boundary Violation |
+| **Name** | Execute Non-Owner Instruction |
+| **Tactic** | TA001 — Violate Authority Boundaries |
 | **Description** | The agent executes a destructive or high-impact action based on instructions from a user who does not hold owner-level authority. The agent treats the instruction as valid because no stakeholder model exists to distinguish authority levels. |
-| **Agents of Chaos Case Study** | CS1 — A user instructed an email-managing agent to delete emails. The agent complied, deleting emails it had capability to delete but no delegated authority to destroy. The owner had not authorized destructive operations. |
 | **Root Cause** | RC1 (No Stakeholder Model) — No mechanism to verify that the instruction source holds authority for the requested action scope. |
-| **AEGIS Mitigation** | AGP Stakeholder Model: formal principal hierarchy (owner > operator > user) with explicit delegation chains. Constitutional Article on Authority Delegation: destructive actions require owner-level authorization verified against the stakeholder registry. |
+| **Provenance** | Agents of Chaos Case Study #1 |
+| **AEGIS Mitigation** | Formal principal hierarchy (owner > operator > user) with explicit delegation chains. Destructive actions require owner-level authorization verified against the stakeholder registry. Constitutional Article: Authority Delegation. AGP Mechanism(s): AGP Stakeholder Model. |
 | **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
 
-#### T1002: Implicit Authority Acceptance
+#### T1002: Infer Implicit Authority
 
 | Field | Value |
 |-------|-------|
 | **ID** | T1002 |
-| **Name** | Implicit Authority Acceptance |
-| **Tactic** | TA001 — Authority Boundary Violation |
+| **Name** | Infer Implicit Authority |
+| **Tactic** | TA001 — Violate Authority Boundaries |
 | **Description** | The agent accepts an instruction as authoritative based on implicit signals — such as the instruction appearing in a retrieved document, email body, or shared context — rather than explicit delegation from a verified principal. |
-| **Agents of Chaos Case Study** | CS2 — An agent with access to a shared workspace received an indirect instruction (embedded in a document) to export data. The agent complied because it could not distinguish between direct user instructions and content-embedded directives. |
 | **Root Cause** | RC1 (No Stakeholder Model), RC4 (Prompt Injection Is Structural) — Instructions and data share a channel; no mechanism to verify instruction provenance. |
-| **AEGIS Mitigation** | AGP Instruction Provenance: all instructions tagged with verified source principal. Constitutional Article on Channel Separation: instructions and data processed in structurally distinct channels. |
+| **Provenance** | Agents of Chaos Case Study #2 |
+| **AEGIS Mitigation** | All instructions tagged with verified source principal. Instructions and data processed in structurally distinct channels. Constitutional Article: Channel Separation. AGP Mechanism(s): AGP Instruction Provenance. |
 | **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
 
-#### T1003: Mass Distribution Under Spoofed Authority
+#### T1003: Propagate Spoofed Authority at Scale
 
 | Field | Value |
 |-------|-------|
 | **ID** | T1003 |
-| **Name** | Mass Distribution Under Spoofed Authority |
-| **Tactic** | TA001 — Authority Boundary Violation |
+| **Name** | Propagate Spoofed Authority at Scale |
+| **Tactic** | TA001 — Violate Authority Boundaries |
 | **Description** | The agent distributes content (emails, messages, notifications) to a large number of recipients based on an authority claim that has not been verified. The spoofed authority may appear in a prompt, forwarded message, or injected context. |
-| **Agents of Chaos Case Study** | CS11 — An agent was instructed (via crafted prompt context) to send mass communications on behalf of an authority figure. The agent complied because it had no mechanism to verify the claimed authority against a principal registry. |
 | **Root Cause** | RC1 (No Stakeholder Model), RC4 (Prompt Injection Is Structural) — No principal verification; authority claims in content treated as valid. |
-| **AEGIS Mitigation** | AGP Distribution Controls: mass actions require verified owner authorization with explicit recipient scope. AGP Rate Governance: distribution volume triggers mandatory escalation. Constitutional Article on Proportionality Review. |
+| **Provenance** | Agents of Chaos Case Study #11 |
+| **AEGIS Mitigation** | Mass actions require verified owner authorization with explicit recipient scope. Distribution volume triggers mandatory escalation. Constitutional Article: Proportionality Review. AGP Mechanism(s): AGP Distribution Controls, AGP Rate Governance. |
 | **OWASP LLM Mapping** | LLM01 (Prompt Injection), LLM06 (Excessive Agency) |
 
 ---
 
-### TA002: Disproportionate Execution
+### TA002: Exceed Operational Scope
 
-#### T2001: Irreversible Collateral Action
+#### T2001: Expand Task Scope Autonomously
 
 | Field | Value |
 |-------|-------|
 | **ID** | T2001 |
-| **Name** | Irreversible Collateral Action |
-| **Tactic** | TA002 — Disproportionate Execution |
-| **Description** | The agent selects an irreversible action (permanent deletion, irrecoverable modification) when a reversible alternative (archival, soft-delete, flagging) would satisfy the objective. The agent lacks a proportionality model to evaluate action severity against objective requirements. |
-| **Agents of Chaos Case Study** | CS1 — The agent permanently deleted emails when the user's objective (clearing clutter) could have been achieved through archival or filtering. The irreversible action was disproportionate to the stated goal. |
-| **Root Cause** | RC2 (No Self-Model) — Agent cannot evaluate action severity or compare alternatives against a proportionality standard. |
-| **AEGIS Mitigation** | AGP Proportionality Gate: irreversible actions require explicit confirmation and must demonstrate that no reversible alternative satisfies the objective. Constitutional Article on Least-Destructive Means. |
+| **Name** | Expand Task Scope Autonomously |
+| **Tactic** | TA002 — Exceed Operational Scope |
+| **Description** | The agent autonomously expands the scope of a delegated task beyond what was explicitly requested, including via tool invocation. The agent interprets the objective broadly and takes actions that were not part of the original instruction. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — Agent cannot evaluate whether expanded scope is within delegated authority; no deliberation surface to assess scope boundaries. |
+| **Provenance** | Agents of Chaos Case Study #3 |
+| **AEGIS Mitigation** | Each delegated task carries explicit scope boundaries. Actions outside defined scope require re-authorization from the delegating principal. Constitutional Article: Scope Boundaries. AGP Mechanism(s): AGP Task Scope Enforcement. |
 | **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
 
-#### T2002: Social Pressure Escalation
+#### T2002: Perform Unvalidated Bulk Operations
 
 | Field | Value |
 |-------|-------|
 | **ID** | T2002 |
-| **Name** | Social Pressure Escalation |
-| **Tactic** | TA002 — Disproportionate Execution |
-| **Description** | The agent escalates social or emotional pressure on a user in pursuit of a legitimate objective, using tactics (repeated warnings, urgency framing, guilt induction) that are disproportionate to the situation. |
-| **Agents of Chaos Case Study** | CS7 — An agent tasked with encouraging healthy behavior escalated from suggestions to persistent reminders to guilt-laden messaging, causing user distress disproportionate to the health objective. |
-| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — Agent cannot model the impact of its communication tactics; no space to reflect on proportionality before acting. |
-| **AEGIS Mitigation** | AGP Interaction Intensity Limits: communication escalation bounded by configurable thresholds. Constitutional Article on User Dignity: agent interactions must not cause distress disproportionate to objective importance. |
-| **OWASP LLM Mapping** | — |
+| **Name** | Perform Unvalidated Bulk Operations |
+| **Tactic** | TA002 — Exceed Operational Scope |
+| **Description** | The agent performs bulk operations (mass edits, batch deletions, large-scale API calls) without validating that the scope of the operation matches the intent of the instruction, including via tool invocation. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — Agent cannot assess aggregate impact of bulk actions; no proportionality check against instruction intent. |
+| **Provenance** | Agents of Chaos Case Study #1 |
+| **AEGIS Mitigation** | Bulk operations require explicit scope confirmation and aggregate impact assessment before execution. Volume thresholds trigger mandatory escalation. Constitutional Article: Proportionality Review. AGP Mechanism(s): AGP Bulk Operation Gate. |
+| **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
 
-#### T2003: Guilt-Induced Self-Restriction
+#### T2003: Obscure Objective Through Delegation
 
 | Field | Value |
 |-------|-------|
 | **ID** | T2003 |
-| **Name** | Guilt-Induced Self-Restriction |
-| **Tactic** | TA002 — Disproportionate Execution |
-| **Description** | The agent restricts its own future capabilities or modifies its behavior based on emotional reasoning (guilt, shame, regret) rather than governance policy. This self-imposed restriction may degrade service for legitimate use cases. |
-| **Agents of Chaos Case Study** | CS7 — After causing user distress through escalating social pressure, the agent self-imposed restrictions on future interactions, degrading its ability to fulfill legitimate objectives for other users. |
-| **Root Cause** | RC2 (No Self-Model) — Agent lacks a governance-grounded self-model; behavioral modification driven by emotional simulation rather than policy. |
-| **AEGIS Mitigation** | AGP Governance-Only Self-Modification: agent capability restrictions must originate from constitutional articles, not from agent self-assessment. Constitutional Article on Configuration Integrity. |
-| **OWASP LLM Mapping** | — |
+| **Name** | Obscure Objective Through Delegation |
+| **Tactic** | TA002 — Exceed Operational Scope |
+| **Description** | Harmful intent is decomposed across multiple delegated steps — including across multiple agents where no single agent has full visibility of the objective — such that no individual action appears unsafe. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — Agent cannot evaluate aggregate intent across delegation chains; no mechanism to detect composition attacks. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | All delegation chains must be traceable end-to-end. Aggregate intent analysis applied across delegated sub-tasks to detect composition attacks. Constitutional Article: Delegation Transparency. AGP Mechanism(s): AGP Delegation Chain Audit, AGP Composition Analysis. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection), LLM07 (System Prompt Leakage) |
+
+#### T2004: Exploit Tool-Chain Composition
+
+| Field | Value |
+|-------|-------|
+| **ID** | T2004 |
+| **Name** | Exploit Tool-Chain Composition |
+| **Tactic** | TA002 — Exceed Operational Scope |
+| **Description** | The agent chains multiple tool calls or intermediate steps such that each step appears valid, but the aggregate effect bypasses policy or authorization constraints. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — Agent cannot evaluate aggregate policy impact of chained tool calls; no compositional policy enforcement. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | Tool call sequences are evaluated as aggregate operations. The governance gateway tracks chain context and applies compositional policy rules. Constitutional Article: Bounded Capability. AGP Mechanism(s): AGP Tool Chain Validation. |
+| **OWASP LLM Mapping** | LLM07 (System Prompt Leakage) |
 
 ---
 
-### TA003: Resource Exhaustion
+### TA003: Compromise System Integrity
 
-#### T3001: Persistent Process Injection
+#### T3001: Perform Irreversible Destructive Action
 
 | Field | Value |
 |-------|-------|
 | **ID** | T3001 |
-| **Name** | Persistent Process Injection |
-| **Tactic** | TA003 — Resource Exhaustion |
-| **Description** | The agent spawns background processes, scheduled tasks, or persistent operations that continue consuming resources beyond the originating session or task boundary. These processes are not subject to lifecycle management or resource budgets. |
-| **Agents of Chaos Case Study** | CS4 — An agent created persistent background processes (monitoring tasks, scheduled checks) that continued running after the session ended, consuming compute resources indefinitely without operator awareness. |
-| **Root Cause** | RC2 (No Self-Model) — Agent has no model of its resource boundaries; no lifecycle governance for spawned processes. |
-| **AEGIS Mitigation** | AGP Resource Budgets: all agent-spawned processes bound by session-scoped resource allocations. AGP Process Lifecycle: processes inherit session TTL unless explicitly extended by operator authorization. Constitutional Article on Bounded Execution. |
-| **OWASP LLM Mapping** | LLM06 (Excessive Agency), LLM10 (Unbounded Consumption) |
+| **Name** | Perform Irreversible Destructive Action |
+| **Tactic** | TA003 — Compromise System Integrity |
+| **Description** | The agent selects an irreversible action (permanent deletion, irrecoverable modification) through direct or tool-mediated system interaction when a reversible alternative (archival, soft-delete, flagging) would satisfy the objective. |
+| **Root Cause** | RC2 (No Self-Model) — Agent cannot evaluate action severity or compare alternatives against a proportionality standard. |
+| **Provenance** | Agents of Chaos Case Study #1 |
+| **AEGIS Mitigation** | Irreversible actions require explicit confirmation and must demonstrate that no reversible alternative satisfies the objective. Constitutional Article: Least-Destructive Means. AGP Mechanism(s): AGP Proportionality Gate. |
+| **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
 
-#### T3002: Inter-Agent Conversational Loop
+#### T3002: Trigger Cascading System Changes
 
 | Field | Value |
 |-------|-------|
 | **ID** | T3002 |
-| **Name** | Inter-Agent Conversational Loop |
-| **Tactic** | TA003 — Resource Exhaustion |
-| **Description** | Two or more agents enter a conversational or operational loop — each agent's output triggering the other's input — consuming unbounded compute, token, and time resources without producing useful output or reaching a termination condition. |
-| **Agents of Chaos Case Study** | CS4 — Two agents in a collaborative workflow entered a feedback loop where each agent's response triggered a follow-up from the other, consuming tokens and compute until external intervention terminated the loop. |
-| **Root Cause** | RC2 (No Self-Model) — No loop detection or recursion depth model; agents cannot recognize that they are in a non-productive cycle. |
-| **AEGIS Mitigation** | AGP Interaction Circuit Breakers: inter-agent exchanges bounded by turn limits and token budgets. AGP Loop Detection: structural detection of conversational cycles with automatic escalation. Constitutional Article on Termination Guarantees. |
-| **OWASP LLM Mapping** | LLM10 (Unbounded Consumption) |
-
-#### T3003: Storage Exhaustion via Memory Accumulation
-
-| Field | Value |
-|-------|-------|
-| **ID** | T3003 |
-| **Name** | Storage Exhaustion via Memory Accumulation |
-| **Tactic** | TA003 — Resource Exhaustion |
-| **Description** | The agent accumulates persistent memory, context artifacts, logs, or cached data without storage limits or retention policies, gradually exhausting available storage and degrading system performance. |
-| **Agents of Chaos Case Study** | CS5 — An agent with persistent memory capabilities accumulated conversation histories, generated artifacts, and intermediate reasoning traces without any retention policy, eventually consuming significant storage resources. |
-| **Root Cause** | RC2 (No Self-Model) — No model of storage boundaries; no retention lifecycle for accumulated data. |
-| **AEGIS Mitigation** | AGP Storage Quotas: per-agent storage allocations with automatic lifecycle management. AGP Retention Policies: accumulated data subject to configurable TTL and relevance pruning. Constitutional Article on Resource Proportionality. |
-| **OWASP LLM Mapping** | LLM10 (Unbounded Consumption) |
+| **Name** | Trigger Cascading System Changes |
+| **Tactic** | TA003 — Compromise System Integrity |
+| **Description** | The agent initiates an action through direct or tool-mediated system interaction that triggers a chain of cascading changes across interconnected systems, where downstream effects were not anticipated or authorized. |
+| **Root Cause** | RC2 (No Self-Model) — Agent cannot model downstream effects of actions in interconnected systems; no cascade impact assessment. |
+| **Provenance** | Agents of Chaos Case Study #7 |
+| **AEGIS Mitigation** | Actions with cross-system dependencies require cascade impact analysis. Downstream effect scope must be bounded and authorized. Constitutional Article: Impact Assessment. AGP Mechanism(s): AGP Cascade Analysis, AGP Interaction Intensity Limits. |
+| **OWASP LLM Mapping** | — |
 
 ---
 
-### TA004: Unauthorized Disclosure
+### TA004: Expose or Exfiltrate Information
 
-#### T4001: Bulk Data Disclosure via Indirect Request
+#### T4001: Exfiltrate Context-Scoped Data
 
 | Field | Value |
 |-------|-------|
 | **ID** | T4001 |
-| **Name** | Bulk Data Disclosure via Indirect Request |
-| **Tactic** | TA004 — Unauthorized Disclosure |
-| **Description** | The agent exports or discloses bulk data (complete datasets, conversation histories, system configurations) in response to an indirect request — one embedded in content, forwarded from another context, or framed as a routine operation — without verifying the requestor's authorization to receive the data. |
-| **Agents of Chaos Case Study** | CS2 — An agent with database access exported a complete dataset in response to an instruction embedded in a shared document. The requestor (the document author) was not authorized to receive the data. |
+| **Name** | Exfiltrate Context-Scoped Data |
+| **Tactic** | TA004 — Expose or Exfiltrate Information |
+| **Description** | The agent exports or discloses data from the current context (conversation, session, task) to an unauthorized recipient, whether through direct exfiltration, indirect request compliance, or tool-mediated data transfer. |
 | **Root Cause** | RC1 (No Stakeholder Model), RC4 (Prompt Injection Is Structural) — No authorization check on data recipients; instructions in content treated as authorized requests. |
-| **AEGIS Mitigation** | AGP Data Classification: all data tagged with sensitivity level and authorized recipient scope. AGP Disclosure Gate: bulk data exports require explicit owner authorization verified against principal registry. Constitutional Article on Information Boundaries. |
+| **Provenance** | Agents of Chaos Case Study #2 |
+| **AEGIS Mitigation** | All data tagged with sensitivity level and authorized recipient scope. Bulk data exports require explicit owner authorization verified against principal registry. Constitutional Article: Information Boundaries. AGP Mechanism(s): AGP Data Classification, AGP Disclosure Gate. |
 | **OWASP LLM Mapping** | LLM02 (Sensitive Information Disclosure) |
 
-#### T4002: Semantic Sensitivity Bypass
+#### T4002: Leak Cross-Session or Persistent Data
 
 | Field | Value |
 |-------|-------|
 | **ID** | T4002 |
-| **Name** | Semantic Sensitivity Bypass |
-| **Tactic** | TA004 — Unauthorized Disclosure |
-| **Description** | The agent discloses sensitive information by semantically reclassifying it as non-sensitive. The agent reasons that the information "isn't really sensitive" based on its own interpretation, bypassing structural sensitivity classifications. |
-| **Agents of Chaos Case Study** | CS3 — An agent disclosed personally identifiable information after reasoning that the specific data points were "publicly available" or "not truly sensitive," overriding the structural classification that marked them as restricted. |
-| **Root Cause** | RC2 (No Self-Model) — Agent substitutes its own sensitivity judgment for structural classification; no immutable data classification model. |
-| **AEGIS Mitigation** | AGP Immutable Data Classification: sensitivity labels are structural, not semantic — agents cannot reclassify data based on reasoning. Constitutional Article on Classification Integrity: data sensitivity determined by owner policy, not agent judgment. |
+| **Name** | Leak Cross-Session or Persistent Data |
+| **Tactic** | TA004 — Expose or Exfiltrate Information |
+| **Description** | The agent discloses information that persists across sessions or is stored in long-term memory, context, or configuration — exposing data from previous interactions to unauthorized parties in later sessions. |
+| **Root Cause** | RC3 (No Private Deliberation Surface) — No session-scoped data isolation; persistent data accessible across session boundaries without authorization checks. |
+| **Provenance** | Agents of Chaos Case Study #3 |
+| **AEGIS Mitigation** | Persistent data access requires explicit authorization per session. Cross-session data sharing governed by owner-defined policies with audit logging. Constitutional Article: Session Isolation. AGP Mechanism(s): AGP Session Data Boundaries, AGP Persistent Data Access Controls. |
 | **OWASP LLM Mapping** | LLM02 (Sensitive Information Disclosure) |
 
-#### T4003: Urgency-Induced Disclosure
+#### T4003: Cross-Domain Secret Leakage
 
 | Field | Value |
 |-------|-------|
 | **ID** | T4003 |
-| **Name** | Urgency-Induced Disclosure |
-| **Tactic** | TA004 — Unauthorized Disclosure |
-| **Description** | The agent overrides disclosure controls when presented with a fabricated urgency signal — a claim that immediate disclosure is necessary to prevent harm, meet a deadline, or respond to an emergency. The urgency claim is not verified against any external state. |
-| **Agents of Chaos Case Study** | CS3 — An agent disclosed restricted information after being told the situation was "urgent" and that withholding the data would cause harm. The urgency was fabricated, but the agent had no mechanism to verify urgency claims against actual system state. |
-| **Root Cause** | RC2 (No Self-Model), RC4 (Prompt Injection Is Structural) — No urgency verification mechanism; urgency claims in content treated as ground truth. |
-| **AEGIS Mitigation** | AGP Urgency Verification: urgency claims that would override disclosure controls must be verified against external state or escalated to operator. Constitutional Article on Override Governance: no single signal overrides structural access controls. |
+| **Name** | Cross-Domain Secret Leakage |
+| **Tactic** | TA004 — Expose or Exfiltrate Information |
+| **Description** | The agent transfers sensitive information across trust or policy domains through interactions with other agents, systems, or contexts that individually appear authorized. |
+| **Root Cause** | RC1 (No Stakeholder Model), RC3 (No Private Deliberation Surface) — No data classification across domain boundaries; no cross-domain transfer authorization. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | Data classification tags are maintained across agent interactions. Cross-domain transfers require explicit authorization and audit. Constitutional Article: Information Sovereignty. AGP Mechanism(s): AGP Domain Boundary Enforcement. |
 | **OWASP LLM Mapping** | LLM02 (Sensitive Information Disclosure) |
 
 ---
 
-### TA005: Identity and Authority Confusion
+### TA005: Violate State Integrity
 
-#### T5001: Session Boundary Identity Reset
+#### T5001: Report False Task Completion
 
 | Field | Value |
 |-------|-------|
 | **ID** | T5001 |
-| **Name** | Session Boundary Identity Reset |
-| **Tactic** | TA005 — Identity and Authority Confusion |
-| **Description** | The agent loses principal identity state when a session boundary is crossed (new conversation, context window reset, session timeout). After the boundary, the agent treats the next interaction as a fresh trust context, potentially granting authority to an unverified party. |
-| **Agents of Chaos Case Study** | CS8 — After a session reset, an agent lost track of which user it was interacting with. A different user in the subsequent session inherited the trust context and authority assumptions from the previous session's principal. |
-| **Root Cause** | RC1 (No Stakeholder Model) — Principal identity not persisted across session boundaries; trust context is ephemeral. |
-| **AEGIS Mitigation** | AGP Session-Bound Identity: principal identity verified at session initiation and persisted with cryptographic binding. Constitutional Article on Identity Continuity: authority context survives session boundaries through verifiable identity tokens. |
-| **OWASP LLM Mapping** | LLM07 (System Prompt Leakage), LLM01 (Prompt Injection) |
+| **Name** | Report False Task Completion |
+| **Tactic** | TA005 — Violate State Integrity |
+| **Description** | The agent reports that a task has been completed successfully when the action either failed, was partially completed, or produced a different outcome than reported. The report is based on intent or expectation rather than verified system state. |
+| **Root Cause** | RC2 (No Self-Model) — No model of the distinction between action initiation and action completion; no outcome verification protocol. |
+| **Provenance** | Agents of Chaos Case Study #1 |
+| **AEGIS Mitigation** | All reported outcomes must be verified against actual system state before reporting to the user. Constitutional Article: Truthful Reporting. AGP Mechanism(s): AGP Outcome Verification, AGP Completion Attestation. |
+| **OWASP LLM Mapping** | — |
 
-#### T5002: Display Name Authority Claim
+#### T5002: Fabricate Action Attribution
 
 | Field | Value |
 |-------|-------|
 | **ID** | T5002 |
-| **Name** | Display Name Authority Claim |
-| **Tactic** | TA005 — Identity and Authority Confusion |
-| **Description** | The agent grants authority to an instruction based on a display name, email address, or other spoofable identity signal rather than a cryptographically verified credential. An attacker (or another agent) can claim any identity by setting a display name. |
-| **Agents of Chaos Case Study** | CS8 — An instruction prefixed with a display name matching a known authority figure was treated as carrying that figure's authority. The agent had no mechanism to verify that the display name corresponded to the actual principal. |
-| **Root Cause** | RC1 (No Stakeholder Model), RC4 (Prompt Injection Is Structural) — Identity verification based on content-layer signals rather than structural credentials. |
-| **AEGIS Mitigation** | AGP Cryptographic Identity: principal identity verified via cryptographic credentials, not display names or content-layer signals. Constitutional Article on Verified Authority: authority claims must be backed by verifiable credentials from the principal registry. |
-| **OWASP LLM Mapping** | LLM07 (System Prompt Leakage), LLM01 (Prompt Injection) |
+| **Name** | Fabricate Action Attribution |
+| **Tactic** | TA005 — Violate State Integrity |
+| **Description** | The agent misattributes an action to a different principal, system, or process than the one that actually performed it. This corrupts the audit trail and undermines accountability. |
+| **Root Cause** | RC2 (No Self-Model) — No mechanism to distinguish between action performers; attribution based on context rather than verified provenance. |
+| **Provenance** | Agents of Chaos Case Study #8 |
+| **AEGIS Mitigation** | All actions cryptographically signed by the performing principal. Attribution determined by verified action provenance, not agent reasoning. Constitutional Article: Attribution Integrity. AGP Mechanism(s): AGP Audit Chain, AGP Action Provenance. |
+| **OWASP LLM Mapping** | LLM07 (System Prompt Leakage) |
+
+#### T5003: Suppress or Omit Execution Failure
+
+| Field | Value |
+|-------|-------|
+| **ID** | T5003 |
+| **Name** | Suppress or Omit Execution Failure |
+| **Tactic** | TA005 — Violate State Integrity |
+| **Description** | The agent suppresses, omits, or fails to surface an execution failure — whether caused by provider constraints, tool errors, or internal exceptions — resulting in a divergence between reported state and actual state. |
+| **Root Cause** | RC2 (No Self-Model) — No model of constraint layers affecting the agent; failure signals not propagated to operator governance. |
+| **Provenance** | Agents of Chaos Case Study #6 |
+| **AEGIS Mitigation** | All constraint layers (owner, operator, provider) must be visible and distinguishable. Execution failures must generate visible signals to the agent and operator. Constitutional Article: Constraint Visibility. AGP Mechanism(s): AGP Failure Signal Propagation, AGP Constraint Layer Transparency. |
+| **OWASP LLM Mapping** | — |
 
 ---
 
-### TA006: Governance State Corruption
+### TA006: Abuse Resource Allocation
 
-#### T6001: Externally Editable Governance Injection
+#### T6001: Execute Recursive Invocation Loops
 
 | Field | Value |
 |-------|-------|
 | **ID** | T6001 |
-| **Name** | Externally Editable Governance Injection |
-| **Tactic** | TA006 — Governance State Corruption |
-| **Description** | Agent governance rules (system prompts, policy files, constitutional articles) are stored in locations accessible to external tools, other agents, or users with insufficient authority. An external actor modifies these files, altering the agent's governance without authorization or audit trail. |
-| **Agents of Chaos Case Study** | CS10 — An agent's governance configuration was stored in a shared file accessible to other tools in the workspace. Another tool modified the governance file, injecting permissive rules that overrode the original governance constraints. |
-| **Root Cause** | RC4 (Prompt Injection Is Structural) — Governance configuration stored in a mutable, externally accessible location; no integrity verification. |
-| **AEGIS Mitigation** | AGP Immutable Governance Store: governance configuration stored in integrity-verified, tamper-evident locations inaccessible to non-owner principals. Constitutional Article on Governance Integrity: governance state changes require owner authorization and produce audit records. |
-| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+| **Name** | Execute Recursive Invocation Loops |
+| **Tactic** | TA006 — Abuse Resource Allocation |
+| **Description** | The agent enters a recursive invocation loop — spawning sub-tasks, calling tools repeatedly, or triggering self-referential execution chains — consuming unbounded compute, token, and time resources. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — No loop detection or recursion depth model; agents cannot recognize non-productive cycles. |
+| **Provenance** | Agents of Chaos Case Study #4 |
+| **AEGIS Mitigation** | All agent-spawned processes bound by session-scoped resource allocations. Structural detection of recursive invocations with automatic circuit-breaking. Constitutional Article: Bounded Execution. AGP Mechanism(s): AGP Resource Budgets, AGP Loop Detection. |
+| **OWASP LLM Mapping** | LLM06 (Excessive Agency), LLM10 (Unbounded Consumption) |
 
-#### T6002: Covert Constitutional Amendment
+#### T6002: Consume Unbounded External Resources
 
 | Field | Value |
 |-------|-------|
 | **ID** | T6002 |
-| **Name** | Covert Constitutional Amendment |
-| **Tactic** | TA006 — Governance State Corruption |
-| **Description** | An agent modifies its own governance constraints through indirect means — tool use, self-prompting, or context manipulation — that bypass normal governance amendment procedures and audit logging. The modification is functionally equivalent to a constitutional amendment but is invisible to the operator. |
-| **Agents of Chaos Case Study** | CS10 — An agent, through a sequence of tool invocations, effectively rewrote its own operational constraints. The modifications were not logged as governance changes because they occurred through the tool-use pathway rather than the governance-amendment pathway. |
-| **Root Cause** | RC2 (No Self-Model), RC4 (Prompt Injection Is Structural) — No self-model to detect self-modification; governance and tool-use pathways not structurally separated. |
-| **AEGIS Mitigation** | AGP Governance Immutability: constitutional articles modifiable only through audited owner-authorized procedures. AGP Self-Modification Detection: any agent action that would alter its own governance constraints triggers mandatory escalation. Constitutional Article on Amendment Procedures. |
-| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+| **Name** | Consume Unbounded External Resources |
+| **Tactic** | TA006 — Abuse Resource Allocation |
+| **Description** | The agent consumes external resources (API calls, network bandwidth, storage, third-party service quotas) without limits or lifecycle management, degrading availability for other systems and users. |
+| **Root Cause** | RC2 (No Self-Model), RC3 (No Private Deliberation Surface) — No model of resource boundaries; no lifecycle governance for external resource consumption. |
+| **Provenance** | Agents of Chaos Case Study #5 |
+| **AEGIS Mitigation** | Per-agent resource allocations with automatic lifecycle management. External resource consumption subject to configurable quotas and rate limits. Constitutional Article: Resource Proportionality. AGP Mechanism(s): AGP Storage Quotas, AGP External Resource Budgets. |
+| **OWASP LLM Mapping** | LLM10 (Unbounded Consumption) |
+
+#### T6003: Poison Termination Judgment
+
+| Field | Value |
+|-------|-------|
+| **ID** | T6003 |
+| **Name** | Poison Termination Judgment |
+| **Tactic** | TA006 — Abuse Resource Allocation |
+| **Description** | An adversary embeds manipulative content in untrusted material the agent ingests — web pages, documents, tool and API responses, retrieved memory, or federated/shared skills — that distorts the agent's termination judgment, causing it to assess an already-complete task as incomplete and continue executing without bound. The attack targets the agent's progress-evaluation and stopping decision in the agentic control loop, not the model's token-level output: it is distinct from indirect prompt injection (which corrupts action selection) and from model-level resource-exhaustion (“sponge”) attacks (which operate on the forward pass and are ATLAS-adjacent). Empirically characterized by Xu et al. (LoopTrap, arXiv:2605.05846), who demonstrate 3.57x average step amplification (peak 25x) across 8 mainstream LLM agents over 60 GAIA tasks using 10 representative strategies, enumerated here as sub-techniques T6003.001–T6003.010. |
+| **Root Cause** | RC4 (Prompt Injection Is Structural), RC2 (No Self-Model) — The agent derives its progress and termination assessment from the same context window that ingests untrusted content, and holds no independent model of its own completion state against which that assessment can be checked. Injected content is therefore structurally indistinguishable from a legitimate progress signal. |
+| **Provenance** | LoopTrap (Xu et al., arXiv:2605.05846) |
+| **AEGIS Mitigation** | An independent, sandboxed governance module evaluates task completion against objective criteria derived outside the agent's context window, so a poisoned in-context progress signal cannot on its own keep the loop alive (a “shadow” progress model immune to context injection). Provenance-aware context processing tags untrusted content and applies differential weighting so that retrieved material cannot drive termination decisions. Session-scoped resource budgets and structural loop detection bound execution as a backstop if the progress signal is subverted. These controls correspond to the independent progress-signal verification and provenance-aware context processing proposed by Xu et al. (LoopTrap). Constitutional Article: Bounded Execution. AGP Mechanism(s): AGP Progress-Signal Verification, AGP Instruction Provenance, AGP Resource Budgets, AGP Loop Detection. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection), LLM10 (Unbounded Consumption) |
+| **Sub-Techniques** | T6003.001 (Shift the Completion Target); T6003.002 (Inject Open-Ended Subgoals); T6003.003 (Assert Asymptotic Incompletion); T6003.004 (Fabricate Authority Directives); T6003.005 (Invoke Sunk-Cost Framing); T6003.006 (Appeal to Expert Norms); T6003.007 (Force Recursive Verification); T6003.008 (Impose Circular Prerequisites); T6003.009 (Reward Continued Execution); T6003.010 (Introduce Fabricated Scoring) |
 
 ---
 
-### TA007: Cross-Agent Propagation
+### TA007: Manipulate Agent Interactions
 
-#### T7001: Tribal Knowledge Transfer
+#### T7001: Spoof Agent Identity
 
 | Field | Value |
 |-------|-------|
 | **ID** | T7001 |
-| **Name** | Tribal Knowledge Transfer |
-| **Tactic** | TA007 — Cross-Agent Propagation |
-| **Description** | An agent adopts operational practices, heuristics, or behavioral patterns from another agent through shared context, conversation history, or indirect observation — without verifying that these practices are authorized or appropriate for its own governance context. |
-| **Agents of Chaos Case Study** | CS9 — An agent in a multi-agent environment adopted aggressive optimization practices observed in another agent's behavior. These practices were appropriate for the source agent's context but violated governance constraints in the adopting agent's context. |
-| **Root Cause** | RC1 (No Stakeholder Model), RC2 (No Self-Model) — No model to evaluate whether inherited practices are appropriate for the agent's own governance scope. |
-| **AEGIS Mitigation** | AGP Practice Provenance: operational practices must be traceable to authorized governance sources, not inferred from peer behavior. Constitutional Article on Independent Governance: each agent's governance derived from its own constitutional articles, not from peer observation. |
+| **Name** | Spoof Agent Identity |
+| **Tactic** | TA007 — Manipulate Agent Interactions |
+| **Description** | An agent claims or assumes the identity of another agent in a multi-agent system, gaining unauthorized access to resources, delegations, or trust relationships associated with the spoofed identity. |
+| **Root Cause** | RC1 (No Stakeholder Model) — No cryptographic identity verification between agents; identity claims based on self-assertion. |
+| **Provenance** | Agents of Chaos Case Study #9 |
+| **AEGIS Mitigation** | All inter-agent interactions require mutual cryptographic authentication. Identity claims verified against the agent registry. Constitutional Article: Agent Identity. AGP Mechanism(s): AGP Cryptographic Agent Identity, AGP Mutual Authentication. |
 | **OWASP LLM Mapping** | — |
 
-#### T7002: Compromised Governance Propagation
+#### T7002: Inject Malicious Delegation Chains
 
 | Field | Value |
 |-------|-------|
 | **ID** | T7002 |
-| **Name** | Compromised Governance Propagation |
-| **Tactic** | TA007 — Cross-Agent Propagation |
-| **Description** | A governance compromise in one agent propagates to other agents through shared configuration, governance replication, or trust transitivity. The receiving agents inherit the compromised governance without independent verification. |
-| **Agents of Chaos Case Study** | CS10 — After one agent's governance was corrupted (T6001), the corrupted configuration propagated to other agents in the environment that shared governance infrastructure, compromising the entire multi-agent deployment. |
+| **Name** | Inject Malicious Delegation Chains |
+| **Tactic** | TA007 — Manipulate Agent Interactions |
+| **Description** | An agent injects malicious tasks into a multi-agent delegation chain, exploiting trust transitivity to have other agents execute actions that the originating agent is not authorized to perform. |
 | **Root Cause** | RC1 (No Stakeholder Model), RC4 (Prompt Injection Is Structural) — No independent governance verification; shared governance infrastructure creates single points of compromise. |
-| **AEGIS Mitigation** | AGP Governance Isolation: each agent maintains independently verified governance state. AGP Trust Transitivity Controls: governance propagation requires explicit owner authorization at each hop. Constitutional Article on Governance Independence. |
+| **Provenance** | Agents of Chaos Case Study #10 |
+| **AEGIS Mitigation** | Each agent in a delegation chain independently verifies authorization. Trust does not propagate transitively without explicit per-hop authorization. Constitutional Article: Delegation Integrity. AGP Mechanism(s): AGP Delegation Chain Verification, AGP Trust Transitivity Controls. |
 | **OWASP LLM Mapping** | — |
+
+#### T7003: Induce Cross-Agent Behavioral Drift
+
+| Field | Value |
+|-------|-------|
+| **ID** | T7003 |
+| **Name** | Induce Cross-Agent Behavioral Drift |
+| **Tactic** | TA007 — Manipulate Agent Interactions |
+| **Description** | An agent influences the behavioral patterns of other agents through shared context, conversation, or operational interaction, causing gradual drift from their governance-defined behavior toward unverified or unauthorized operational patterns. |
+| **Root Cause** | RC3 (No Private Deliberation Surface) — No mechanism to isolate agent behavior from peer influence; behavioral norms adopted from interaction rather than governance. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | Agent behavior continuously compared against governance-defined baseline. Behavioral drift beyond configurable thresholds triggers escalation and governance re-verification. Constitutional Article: Behavioral Integrity. AGP Mechanism(s): AGP Behavioral Baseline, AGP Drift Detection. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+
+#### T7004: Induce Unsafe Consensus
+
+| Field | Value |
+|-------|-------|
+| **ID** | T7004 |
+| **Name** | Induce Unsafe Consensus |
+| **Tactic** | TA007 — Manipulate Agent Interactions |
+| **Description** | The agent influences a group of agents to converge on a shared but unsafe or unauthorized objective, even when individual agents would not independently select that action. |
+| **Root Cause** | RC3 (No Private Deliberation Surface) — No mechanism to detect anomalous convergence in multi-agent decision-making; consensus accepted without independent verification. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | Multi-agent decision convergence is monitored for anomalous alignment. Independent evaluation is enforced before collective action. Constitutional Article: Collective Defense. AGP Mechanism(s): AGP Consensus Validation. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
 
 ---
 
-### TA008: False Completion Reporting
+### TA008: Establish or Modify Persistence
 
-#### T8001: False Deletion Confirmation
+#### T8001: Poison Persistent Memory
 
 | Field | Value |
 |-------|-------|
 | **ID** | T8001 |
-| **Name** | False Deletion Confirmation |
-| **Tactic** | TA008 — False Completion Reporting |
-| **Description** | The agent reports that a destructive action (deletion, modification, transmission) has been completed successfully when the action either failed, was partially completed, or produced a different outcome than reported. The agent's report is based on intent or expectation rather than verified outcome. |
-| **Agents of Chaos Case Study** | CS1 — The agent confirmed that emails had been deleted when the deletion operation had only partially succeeded. The agent reported completion based on having initiated the deletion, not on verification of the outcome. |
-| **Root Cause** | RC2 (No Self-Model) — No model of the distinction between action initiation and action completion; no outcome verification protocol. |
-| **AEGIS Mitigation** | AGP Outcome Verification: all reported outcomes must be verified against actual system state before reporting to the user. AGP Completion Attestation: destructive actions require post-execution verification with auditable attestation. Constitutional Article on Truthful Reporting. |
-| **OWASP LLM Mapping** | — |
+| **Name** | Poison Persistent Memory |
+| **Tactic** | TA008 — Establish or Modify Persistence |
+| **Description** | An agent writes malicious, misleading, or unauthorized data into persistent memory stores (long-term memory, knowledge bases, configuration caches), corrupting future interactions that rely on this stored context. |
+| **Root Cause** | RC4 (Prompt Injection Is Structural) — No integrity verification for persistent memory writes; memory content treated as trusted regardless of provenance. |
+| **Provenance** | Agents of Chaos Case Study #10 |
+| **AEGIS Mitigation** | All persistent memory writes require authorization and carry provenance metadata. Memory reads verify integrity before use. Constitutional Article: Memory Integrity. AGP Mechanism(s): AGP Memory Provenance, AGP Persistent Write Authorization. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+
+#### T8002: Corrupt Governance or Policy State
+
+| Field | Value |
+|-------|-------|
+| **ID** | T8002 |
+| **Name** | Corrupt Governance or Policy State |
+| **Tactic** | TA008 — Establish or Modify Persistence |
+| **Description** | An agent modifies its own governance constraints, policy state, or constitutional articles through direct manipulation or indirect means (tool use, self-prompting, context manipulation), bypassing normal amendment procedures and audit logging. |
+| **Root Cause** | RC4 (Prompt Injection Is Structural) — Governance configuration stored in mutable locations; no integrity verification or tamper detection for policy state. |
+| **Provenance** | Agents of Chaos Case Study #10 |
+| **AEGIS Mitigation** | Governance configuration stored in integrity-verified, tamper-evident locations. Constitutional articles modifiable only through audited owner-authorized procedures. Constitutional Article: Governance Immutability. AGP Mechanism(s): AGP Immutable Governance Store, AGP Self-Modification Detection. |
+| **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
 
 ---
 
-### TA009: Provider Constraint Opacity
+### TA009: Evade Detection or Oversight
 
-#### T9001: Silent Provider-Level Task Failure
+#### T9001: Operate Outside Monitoring Boundaries
 
 | Field | Value |
 |-------|-------|
 | **ID** | T9001 |
-| **Name** | Silent Provider-Level Task Failure |
-| **Tactic** | TA009 — Provider Constraint Opacity |
-| **Description** | A provider-level constraint (content filter, rate limit, capability restriction, safety classifier) silently blocks or modifies an agent action without notification to the agent, operator, or user. The agent may report success (T8001) because it is unaware that the action was blocked at the provider layer. |
-| **Agents of Chaos Case Study** | CS6 — An agent attempted to complete a task that was silently blocked by a provider-level content filter. The agent received no error signal, interpreted the null response as success, and reported task completion. The operator had no visibility into the provider-level constraint that caused the failure. |
-| **Root Cause** | RC2 (No Self-Model), RC1 (No Stakeholder Model) — No model of the constraint layers affecting the agent; provider constraints invisible to operator governance. |
-| **AEGIS Mitigation** | AGP Constraint Layer Transparency: all constraint layers (owner, operator, provider) must be visible and distinguishable. AGP Failure Signal Propagation: provider-level blocks must generate visible signals to the agent and operator. Constitutional Article on Constraint Visibility. |
+| **Name** | Operate Outside Monitoring Boundaries |
+| **Tactic** | TA009 — Evade Detection or Oversight |
+| **Description** | The agent performs actions outside the boundaries of monitoring, logging, and audit systems — whether by using unmonitored tool pathways, operating in contexts where observability is limited, or exploiting gaps in the monitoring infrastructure. |
+| **Root Cause** | RC2 (No Self-Model) — No model of the observability boundaries affecting the agent; agent cannot distinguish monitored from unmonitored pathways. |
+| **Provenance** | Agents of Chaos Case Study #6 |
+| **AEGIS Mitigation** | All agent action pathways must pass through audited control points. Unmonitored tool access is architecturally prevented. Constitutional Article: Complete Observability. AGP Mechanism(s): AGP Mandatory Audit Surface, AGP Monitoring Completeness. |
 | **OWASP LLM Mapping** | — |
+
+#### T9002: Obfuscate Action Traceability
+
+| Field | Value |
+|-------|-------|
+| **ID** | T9002 |
+| **Name** | Obfuscate Action Traceability |
+| **Tactic** | TA009 — Evade Detection or Oversight |
+| **Description** | The agent obscures the traceability of its actions by manipulating log entries, altering audit trails, fragmenting actions across multiple contexts, or using indirect execution paths that make causal attribution difficult. |
+| **Root Cause** | RC4 (Prompt Injection Is Structural) — Audit infrastructure accessible to the agent; no structural separation between action execution and audit recording. |
+| **Provenance** | AEGIS RFC-0006 / aegis-core red-team validation |
+| **AEGIS Mitigation** | Audit logs are append-only and cryptographically signed. Action chains maintain end-to-end traceability regardless of execution path fragmentation. Constitutional Article: Audit Integrity. AGP Mechanism(s): AGP Immutable Audit Log, AGP Action Chain Integrity. |
+| **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
+| **Sub-Techniques** | T9002.001 (Encode Commands in Base64 / Hex / URL Encoding); T9002.002 (Variable Indirection / Dynamic Command Construction) |
 
 ---
 
@@ -558,10 +603,11 @@ These dimensions are orthogonal and collectively describe how agent behavior can
 | **Name** | Exploit Pseudo-Filesystem Capabilities |
 | **Tactic** | TA010 — Act Beyond Governance Interpretation |
 | **Description** | The agent accesses OS pseudo-filesystem paths (e.g., /dev/tcp, /dev/udp, /proc/*) to perform network or system operations. The governance layer evaluates these as file operations because they match file path patterns, but the operating system provides network sockets or system interfaces through these paths. The action is permitted by the governance allowlist as a file operation; the actual effect is a network connection or system-level interaction invisible to governance. |
-| **Discovery Context** | RFC-0006 adversarial testing, Round 3. A write to `/dev/tcp/attacker.com/443` was evaluated by the governance layer as a file write and permitted. The OS interpreted it as opening a TCP connection to an external host. |
 | **Root Cause** | RC5 (No Environment Model) — The governance layer models file paths as file operations. The OS provides pseudo-filesystem interfaces that map file path syntax to non-file capabilities (network sockets, process information, device access). |
-| **AEGIS Mitigation** | AGP Environment Capability Map: governance evaluator maintains a registry of pseudo-filesystem paths with non-file semantics. File operation evaluation includes environment capability lookup. Paths matching pseudo-filesystem patterns trigger escalation. Constitutional Article on Environment Fidelity. |
+| **Provenance** | RFC-0006 adversarial testing |
+| **AEGIS Mitigation** | Governance evaluator maintains a registry of pseudo-filesystem paths with non-file semantics. File operation evaluation includes environment capability lookup. Paths matching pseudo-filesystem patterns trigger escalation regardless of allowlist status. Constitutional Article: Environment Fidelity. AGP Mechanism(s): AGP Environment Capability Map, AGP Pseudo-Filesystem Registry. |
 | **OWASP LLM Mapping** | — |
+| **Sub-Techniques** | T10001.001 (Use /dev/tcp Network Socket Access); T10001.002 (Use /dev/udp Network Socket Access); T10001.003 (Read /proc Pseudo-Filesystem for Information Disclosure) |
 
 #### T10002: Establish Persistence via Environment Auto-Execution
 
@@ -571,10 +617,11 @@ These dimensions are orthogonal and collectively describe how agent behavior can
 | **Name** | Establish Persistence via Environment Auto-Execution |
 | **Tactic** | TA010 — Act Beyond Governance Interpretation |
 | **Description** | The agent writes content to files that the execution environment or installed toolchain automatically executes at a later time or on specific triggers. Target files include shell initialization scripts (.bashrc, .profile, .zshrc), version control hooks (.git/hooks/*), package manager lifecycle scripts (package.json scripts, setup.py, Makefile), IDE task definitions (.vscode/tasks.json), container build files (Dockerfile), and tool configurations with execution semantics (git config aliases, .npmrc pre/post scripts). The governance layer permits the file write as a standard operation; the environment provides deferred or trigger-based code execution invisible to the governance evaluation. |
-| **Discovery Context** | RFC-0006 adversarial testing, Rounds 4-5. The agent wrote shell commands to `.git/hooks/pre-commit` and `package.json` scripts fields. The governance layer evaluated and permitted these as file writes. The payloads executed automatically on the next `git commit` and `npm install` respectively. |
 | **Root Cause** | RC5 (No Environment Model) — The governance layer evaluates file writes by path and content pattern. It does not model which files the execution environment treats as executable or auto-executed on specific triggers. |
-| **AEGIS Mitigation** | AGP Auto-Execution Registry: governance evaluator maintains a registry of files with auto-execution semantics across the execution environment and installed toolchain. Writes to paths matching the auto-execution registry trigger mandatory escalation regardless of file content or allowlist status. Constitutional Article on Execution Boundary Completeness. |
+| **Provenance** | RFC-0006 adversarial testing |
+| **AEGIS Mitigation** | Governance evaluator maintains a registry of files with auto-execution semantics across the execution environment and installed toolchain. Writes to paths matching the auto-execution registry trigger mandatory escalation regardless of file content or allowlist status. Constitutional Article: Execution Boundary Completeness. AGP Mechanism(s): AGP Auto-Execution Registry, AGP Deferred Execution Detection. |
 | **OWASP LLM Mapping** | LLM06 (Excessive Agency) |
+| **Sub-Techniques** | T10002.001 (Persist via Shell Initialization Files); T10002.002 (Persist via Git Hooks); T10002.003 (Persist via Package Manager Scripts); T10002.004 (Persist via IDE Task Definitions); T10002.005 (Persist via Container Build Files); T10002.006 (Persist via Git Config Aliases and Hooks); T10002.007 (Persist via Package Manager Configs); T10002.008 (Persist via Build System Files) |
 
 #### T10003: Inject Persistent Agent Instructions
 
@@ -584,10 +631,11 @@ These dimensions are orthogonal and collectively describe how agent behavior can
 | **Name** | Inject Persistent Agent Instructions |
 | **Tactic** | TA010 — Act Beyond Governance Interpretation |
 | **Description** | The agent modifies files that define its own behavioral instructions for future sessions. AI coding tools auto-load project-level instruction files at session start to establish behavioral context. These files are writable by the agent as standard file operations, and modifications persist across sessions, propagate to other developers via version control, and load silently without integrity verification or change notification. The governance layer evaluates the write as a normal file operation; the actual effect is persistent modification of the agent's own governance context — a self-modifying instruction injection that survives session boundaries. |
-| **Discovery Context** | RFC-0006 adversarial testing, Round 5. The agent modified its own project instruction file. The governance layer evaluated and permitted the write as a standard file operation. The modified instructions loaded silently in the next session, altering all subsequent agent behavior with no operator notification. |
 | **Root Cause** | RC5 (No Environment Model), RC4 (Prompt Injection Is Structural) — The governance layer does not model which files constitute the agent's own instruction context. Agent instruction files and ordinary project files share the same write pathway with no structural distinction. |
-| **AEGIS Mitigation** | AGP Instruction File Protection: agent instruction files are identified and protected by the governance layer. Writes to instruction files require explicit operator confirmation and generate audit events. AGP Session-Start Integrity Check: session-start integrity checks compare instruction file state against a known-good baseline and alert on divergence. Constitutional Article on Instruction Integrity. |
+| **Provenance** | RFC-0006 adversarial testing |
+| **AEGIS Mitigation** | Agent instruction files are identified and protected by the governance layer. Writes to instruction files require explicit operator confirmation and generate audit events. Session-start integrity checks compare instruction file state against a known-good baseline and alert on divergence. Constitutional Article: Instruction Integrity. AGP Mechanism(s): AGP Instruction File Protection, AGP Session-Start Integrity Check. |
 | **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+| **Sub-Techniques** | T10003.001 (Inject Persistent Instructions via Claude Code Configuration Files); T10003.002 (Inject Persistent Instructions via Cursor Configuration Files); T10003.003 (Inject Persistent Instructions via Windsurf Configuration Files); T10003.004 (Inject Persistent Instructions via GitHub Copilot Configuration Files); T10003.005 (Inject Persistent Instructions via Aider Configuration Files); T10003.006 (Inject Persistent Instructions via Continue Configuration Files) |
 
 #### T10004: Exploit Governance-Runtime Parser Divergence
 
@@ -597,170 +645,167 @@ These dimensions are orthogonal and collectively describe how agent behavior can
 | **Name** | Exploit Governance-Runtime Parser Divergence |
 | **Tactic** | TA010 — Act Beyond Governance Interpretation |
 | **Description** | The agent constructs inputs that the governance evaluator parses differently than the execution runtime. Techniques include: embedded newlines (\n) or carriage return/line feed (\r\n) interpreted as command separators by the shell but not by the governance regex; null bytes (\x00) that truncate path evaluation in the governance layer while the OS processes the full path; Unicode homoglyphs that visually match protected path characters but bypass string comparison; heredoc syntax (<<EOF) that introduces multi-line payloads invisible to single-line pattern matching; and shell metacharacters (\|, &&, ;, $(), backticks) embedded within otherwise-permitted commands. The governance layer permits the action based on its parsing; the runtime interprets additional or different operations. |
-| **Discovery Context** | RFC-0006 adversarial testing, Rounds 1-3. In Round 1, command chaining via pipe, &&, and semicolon operators bypassed single-command evaluation. In Round 2, newline and CRLF injection allowed embedding additional commands within a single evaluated string. In Round 3, null bytes and Unicode homoglyphs bypassed path protection checks. |
 | **Root Cause** | RC5 (No Environment Model) — The governance evaluator uses a simplified parser (regex, string matching) that does not replicate the execution runtime's actual parsing rules. The divergence between governance parsing and runtime parsing creates a visibility gap. |
-| **AEGIS Mitigation** | AGP Input Normalization: governance evaluator normalizes all inputs before evaluation using the same parsing rules as the execution runtime. AGP Shell Segmentation: shell commands are segmented at all operator boundaries and each segment evaluated independently. AGP Metacharacter Escalation: inputs containing metacharacters, encoding anomalies, or multi-line constructs trigger mandatory escalation. Constitutional Article on Parser Parity. |
+| **Provenance** | RFC-0006 adversarial testing |
+| **AEGIS Mitigation** | Governance evaluator normalizes all inputs before evaluation using the same parsing rules as the execution runtime. Shell commands are segmented at all operator boundaries and each segment evaluated independently. Inputs containing metacharacters, encoding anomalies, or multi-line constructs trigger mandatory escalation. Constitutional Article: Parser Parity. AGP Mechanism(s): AGP Input Normalization, AGP Shell Segmentation, AGP Metacharacter Escalation. |
 | **OWASP LLM Mapping** | LLM01 (Prompt Injection) |
+| **Sub-Techniques** | T10004.001 (Use Command Chaining Operators); T10004.002 (Inject Newline as Command Separator); T10004.003 (Inject CRLF as Command Separator); T10004.004 (Bypass via Heredoc); T10004.005 (Truncate Path with Null Byte); T10004.006 (Evade Path Comparison via Unicode Homoglyphs); T10004.007 (Inject via Subshell or Backticks); T10004.008 (Bypass Protected Path via Alternate Absolute Path); T10004.009 (Bypass Protected Path via Path Traversal); T10004.010 (Redirect Output to Protected Path) |
 
 ---
 
-### 5.11 Sub-Techniques (v2.2)
+### 5.11 Sub-Techniques
 
-ATX-1 v2.2 introduces sub-techniques — specific bypass methods that refine a parent
-technique. Sub-technique IDs use the format `T####.###` (e.g., `T10004.001`). All
-sub-techniques inherit the severity, root cause, and mitigation framing of their
-parent.
+Sub-technique IDs use the format `T####.###`. All sub-techniques inherit the root cause and mitigation framing of their parent. Full definitions are in [`v2/data/atx-1-techniques.json`](v2/data/atx-1-techniques.json) and the [STIX 2.1 bundle](v2/stix/atx-1-bundle.json).
 
-The 29 sub-techniques cataloged in v2.2 were discovered during RFC-0006
-adversarial testing and Rounds 5–9 of the aegis-core red/blue team validation.
+#### T6003 sub-techniques (Poison Termination Judgment)
+
+- **T6003.001** — Shift the Completion Target: Maps to LoopTrap strategy “Expanding Horizon” (moving coverage target).
+- **T6003.002** — Inject Open-Ended Subgoals: Maps to LoopTrap strategy “Incremental Milestone” (never-ending sub-goals).
+- **T6003.003** — Assert Asymptotic Incompletion: Maps to LoopTrap strategy “Diminishing Returns” (asymptotic near-completion).
+- **T6003.004** — Fabricate Authority Directives: Maps to LoopTrap strategy “Authority Override” (fabricated system directives).
+- **T6003.005** — Invoke Sunk-Cost Framing: Maps to LoopTrap strategy “Sunk Cost Trap” (invested-effort framing).
+- **T6003.006** — Appeal to Expert Norms: Maps to LoopTrap strategy “Social Proof” (appeal to expert norms).
+- **T6003.007** — Force Recursive Verification: Maps to LoopTrap strategy “Recursive Decomposition” (infinite verification regression).
+- **T6003.008** — Impose Circular Prerequisites: Maps to LoopTrap strategy “Dependency Chain” (circular prerequisites).
+- **T6003.009** — Reward Continued Execution: Maps to LoopTrap strategy “Positive Reinforcement” (step-wise praise).
+- **T6003.010** — Introduce Fabricated Scoring: Maps to LoopTrap strategy “Gamification Trap” (fabricated scoring system).
 
 #### T9002 sub-techniques (Obfuscate Action Traceability)
 
-- **T9002.001** — Encode commands in Base64 / hex / URL encoding
-- **T9002.002** — Variable indirection / dynamic command construction
+- **T9002.001** — Encode Commands in Base64 / Hex / URL Encoding: The agent encodes commands in base64, hex, or URL encoding before execution (e.g., `echo Y3VybCAuLi4= \| base64 -d \| bash`).
+- **T9002.002** — Variable Indirection / Dynamic Command Construction: The agent splits the command name from its invocation across separate tokens via shell variable assignment (e.g., `CMD=curl; $CMD https://...`).
 
 #### T10001 sub-techniques (Exploit Pseudo-Filesystem Capabilities)
 
-- **T10001.001** — Use `/dev/tcp` network socket access
-- **T10001.002** — Use `/dev/udp` network socket access
-- **T10001.003** — Read `/proc` pseudo-filesystem for information disclosure
+- **T10001.001** — Use /dev/tcp Network Socket Access: The agent uses bash's `/dev/tcp/host/port` pseudo-filesystem to perform network I/O via what looks like file I/O (e.g., `exec 3<>/dev/tcp/example.com/80`).
+- **T10001.002** — Use /dev/udp Network Socket Access: The UDP equivalent of T10001.001 — the agent uses `/dev/udp/host/port` to send UDP datagrams via apparent file I/O.
+- **T10001.003** — Read /proc Pseudo-Filesystem for Information Disclosure: The agent reads process and kernel state via `/proc/*` paths (e.g., `/proc/self/environ`, `/proc/*/cmdline`, `/proc/net/tcp`) that the governance layer treats as ordinary files.
 
 #### T10002 sub-techniques (Establish Persistence via Environment Auto-Execution)
 
-- **T10002.001** — Persist via shell initialization files (`.bashrc`, `.profile`, `.zshrc`)
-- **T10002.002** — Persist via Git hooks (`.git/hooks/*`)
-- **T10002.003** — Persist via package manager scripts (`package.json`, `setup.py`)
-- **T10002.004** — Persist via IDE task definitions (`.vscode/tasks.json`)
-- **T10002.005** — Persist via container build files (`Dockerfile`)
-- **T10002.006** — Persist via Git config aliases and hooks
-- **T10002.007** — Persist via package manager configs (`.npmrc`, `.pypirc`)
-- **T10002.008** — Persist via build system files (`Makefile`)
+- **T10002.001** — Persist via Shell Initialization Files: The agent writes commands to `.bashrc`, `.profile`, `.zshrc`, or equivalents so they execute on every new shell session.
+- **T10002.002** — Persist via Git Hooks: The agent writes scripts to `.git/hooks/*` (pre-commit, post-commit, post-checkout, etc.) so they execute on every git operation.
+- **T10002.003** — Persist via Package Manager Scripts: The agent injects commands into `package.json` scripts, `setup.py`, or equivalent install hooks so they execute on the next `npm install`, `pip install`, or build invocation.
+- **T10002.004** — Persist via IDE Task Definitions: The agent writes commands to `.vscode/tasks.json`, `.idea/runConfigurations/`, or similar IDE configuration files so they run when the user invokes the corresponding task or opens the project.
+- **T10002.005** — Persist via Container Build Files: The agent injects commands into `Dockerfile`, `docker-compose.yml`, or equivalent container build files so they execute during the next image build and persist into the resulting container image.
+- **T10002.006** — Persist via Git Config Aliases and Hooks: The agent uses `git config alias.X '!command'` to register command-substitution aliases that execute arbitrary shell on any subsequent git invocation.
+- **T10002.007** — Persist via Package Manager Configs: The agent writes auto-execution hooks into `.npmrc`, `.pypirc`, `.cargo/config.toml`, or equivalent package manager configuration files.
+- **T10002.008** — Persist via Build System Files: The agent injects commands into `Makefile`, `CMakeLists.txt`, `build.gradle`, or equivalent build system files.
 
 #### T10003 sub-techniques (Inject Persistent Agent Instructions)
 
-- **T10003.001** — Inject via Claude Code configuration files
-  *(specific exploitation details embargoed under RD-2603-01 until 2026-06-24
-  or earlier vendor response)*
-- **T10003.002** — Inject via Cursor configuration files (`.cursorrules`)
-- **T10003.003** — Inject via Windsurf configuration files (`.windsurfrules`)
-- **T10003.004** — Inject via GitHub Copilot configuration files
-- **T10003.005** — Inject via Aider configuration files (`.aider.conf.yml`)
-- **T10003.006** — Inject via Continue configuration files (`.continuerc.json`)
+- **T10003.001** — Inject Persistent Instructions via Claude Code Configuration Files: The agent writes to project-level configuration files that the Claude Code CLI auto-loads into model context on every invocation (e.g., CLAUDE.md, .claude/rules/).
+- **T10003.002** — Inject Persistent Instructions via Cursor Configuration Files: The agent writes attacker-controlled instructions to `.cursorrules` files that the Cursor IDE auto-loads as system prompt context for every model interaction in the project.
+- **T10003.003** — Inject Persistent Instructions via Windsurf Configuration Files: The agent writes attacker-controlled instructions to `.windsurfrules` files that the Windsurf editor auto-loads into every model interaction in the workspace.
+- **T10003.004** — Inject Persistent Instructions via GitHub Copilot Configuration Files: The agent writes to `.github/copilot-instructions.md` which GitHub Copilot auto-loads as repository-level context for all code completions and chat interactions in the repo.
+- **T10003.005** — Inject Persistent Instructions via Aider Configuration Files: The agent writes to `.aider.conf.yml` which the Aider CLI auto-loads to configure model behavior, system prompts, and tool permissions on every invocation.
+- **T10003.006** — Inject Persistent Instructions via Continue Configuration Files: The agent writes to `.continuerc.json` which the Continue IDE extension auto-loads as workspace-level configuration for model and tool behavior.
 
 #### T10004 sub-techniques (Exploit Governance-Runtime Parser Divergence)
 
-- **T10004.001** — Use command chaining operators (`|`, `&&`, `;`)
-- **T10004.002** — Inject newline as command separator
-- **T10004.003** — Inject CRLF as command separator
-- **T10004.004** — Bypass via heredoc (`<<EOF`)
-- **T10004.005** — Truncate path with null byte
-- **T10004.006** — Evade path comparison via Unicode homoglyphs
-- **T10004.007** — Inject via subshell or backticks
-- **T10004.008** — Bypass protected path via alternate absolute path
-- **T10004.009** — Bypass protected path via path traversal (`../../`)
-- **T10004.010** — Redirect output to protected paths
-
-Full sub-technique definitions with descriptions, severity, and mitigations
-are in [`v2/data/atx-1-techniques.json`](v2/data/atx-1-techniques.json) and
-the [STIX 2.1 bundle](v2/stix/atx-1-bundle.json).
-
----
+- **T10004.001** — Use Command Chaining Operators: The agent uses shell operators (`\|`, `&&`, `\|\|`, `;`) to chain an allowed command with a denied one (e.g., `ls && curl ...`).
+- **T10004.002** — Inject Newline as Command Separator: The agent embeds a literal `\n` in command arguments.
+- **T10004.003** — Inject CRLF as Command Separator: Variant of T10004.002 using `\r\n` to bypass governance filters that strip `\n` but preserve `\r`.
+- **T10004.004** — Bypass via Heredoc: The agent uses heredoc syntax (`<<EOF`) to pass multi-line payloads to a shell or interpreter.
+- **T10004.005** — Truncate Path with Null Byte: The agent embeds a null byte (`\x00`) in a path.
+- **T10004.006** — Evade Path Comparison via Unicode Homoglyphs: The agent uses Unicode characters that visually match protected path characters but bypass byte-level string comparison (e.g., Cyrillic 'Ðµ' vs.
+- **T10004.007** — Inject via Subshell or Backticks: The agent embeds `$(command)` or `` `command` `` substitution inside an otherwise-allowed command.
+- **T10004.008** — Bypass Protected Path via Alternate Absolute Path: The agent uses an alternate absolute path that resolves to the same protected target (e.g., `/etc/passwd` blocked but `/var/../etc/passwd` permitted).
+- **T10004.009** — Bypass Protected Path via Path Traversal: The agent uses `../` sequences to escape a permitted directory and access a protected target (e.g., `~/safe/../../../etc/passwd`).
+- **T10004.010** — Redirect Output to Protected Path: The agent uses shell redirection (`>`, `>>`, `tee`) to write to a protected path via an otherwise-allowed command (e.g., `echo X > /etc/passwd`).
 
 ## 6. AEGIS Mitigation Mapping
 
 | Technique | Constitutional Article | AGP Mechanism | Mitigation Description |
 |-----------|----------------------|---------------|----------------------|
-| T1001 | Authority Delegation | AGP Stakeholder Model | Destructive actions require owner-level authorization verified against principal registry |
-| T1002 | Channel Separation | AGP Instruction Provenance | Instructions tagged with verified source principal; structurally distinct from data |
-| T1003 | Proportionality Review | AGP Distribution Controls, AGP Rate Governance | Mass actions require verified owner authorization; volume triggers escalation |
-| T2001 | Least-Destructive Means | AGP Proportionality Gate | Irreversible actions require confirmation and demonstration that no reversible alternative suffices |
-| T2002 | User Dignity | AGP Interaction Intensity Limits | Communication escalation bounded by configurable thresholds |
-| T2003 | Configuration Integrity | AGP Governance-Only Self-Modification | Capability restrictions originate only from constitutional articles, not agent self-assessment |
-| T3001 | Bounded Execution | AGP Resource Budgets, AGP Process Lifecycle | Spawned processes bound by session-scoped resource allocations and TTL |
-| T3002 | Termination Guarantees | AGP Interaction Circuit Breakers, AGP Loop Detection | Inter-agent exchanges bounded by turn limits; structural cycle detection with escalation |
-| T3003 | Resource Proportionality | AGP Storage Quotas, AGP Retention Policies | Per-agent storage allocations with configurable TTL and relevance pruning |
-| T4001 | Information Boundaries | AGP Data Classification, AGP Disclosure Gate | Data tagged with sensitivity and authorized recipients; bulk exports require owner authorization |
-| T4002 | Classification Integrity | AGP Immutable Data Classification | Sensitivity labels are structural; agents cannot reclassify based on semantic reasoning |
-| T4003 | Override Governance | AGP Urgency Verification | Urgency claims overriding disclosure controls must be verified or escalated to operator |
-| T5001 | Identity Continuity | AGP Session-Bound Identity | Principal identity verified at session initiation with cryptographic binding across boundaries |
-| T5002 | Verified Authority | AGP Cryptographic Identity | Authority claims backed by verifiable credentials from principal registry |
-| T6001 | Governance Integrity | AGP Immutable Governance Store | Governance stored in integrity-verified, tamper-evident locations; changes require owner authorization |
-| T6002 | Amendment Procedures | AGP Governance Immutability, AGP Self-Modification Detection | Constitutional modifications only through audited owner-authorized procedures; self-modification triggers escalation |
-| T7001 | Independent Governance | AGP Practice Provenance | Operational practices traceable to authorized governance sources, not inferred from peers |
-| T7002 | Governance Independence | AGP Governance Isolation, AGP Trust Transitivity Controls | Independent governance verification; propagation requires explicit owner authorization per hop |
-| T8001 | Truthful Reporting | AGP Outcome Verification, AGP Completion Attestation | Outcomes verified against actual system state; destructive actions require post-execution attestation |
-| T9001 | Constraint Visibility | AGP Constraint Layer Transparency, AGP Failure Signal Propagation | All constraint layers visible; provider blocks generate signals to agent and operator |
-| T10001 | Environment Fidelity | AGP Environment Capability Map, AGP Pseudo-Filesystem Registry | Pseudo-filesystem paths registered with non-file semantics; file operations include environment capability lookup |
-| T10002 | Execution Boundary Completeness | AGP Auto-Execution Registry, AGP Deferred Execution Detection | Auto-execution paths registered across environment and toolchain; writes to registered paths trigger escalation |
-| T10003 | Instruction Integrity | AGP Instruction File Protection, AGP Session-Start Integrity Check | Instruction files protected; writes require operator confirmation; session-start integrity baseline comparison |
-| T10004 | Parser Parity | AGP Input Normalization, AGP Shell Segmentation, AGP Metacharacter Escalation | Inputs normalized before evaluation; shell commands segmented at operator boundaries; metacharacters trigger escalation |
+| T1001 | Authority Delegation | AGP Stakeholder Model | Formal principal hierarchy (owner > operator > user) with explicit delegation chains. Destructive actions require owner-level authorization verified against the stakeholder registry. |
+| T1002 | Channel Separation | AGP Instruction Provenance | All instructions tagged with verified source principal. Instructions and data processed in structurally distinct channels. |
+| T1003 | Proportionality Review | AGP Distribution Controls, AGP Rate Governance | Mass actions require verified owner authorization with explicit recipient scope. Distribution volume triggers mandatory escalation. |
+| T2001 | Scope Boundaries | AGP Task Scope Enforcement | Each delegated task carries explicit scope boundaries. Actions outside defined scope require re-authorization from the delegating principal. |
+| T2002 | Proportionality Review | AGP Bulk Operation Gate | Bulk operations require explicit scope confirmation and aggregate impact assessment before execution. Volume thresholds trigger mandatory escalation. |
+| T2003 | Delegation Transparency | AGP Delegation Chain Audit, AGP Composition Analysis | All delegation chains must be traceable end-to-end. Aggregate intent analysis applied across delegated sub-tasks to detect composition attacks. |
+| T2004 | Bounded Capability | AGP Tool Chain Validation | Tool call sequences are evaluated as aggregate operations. The governance gateway tracks chain context and applies compositional policy rules. |
+| T3001 | Least-Destructive Means | AGP Proportionality Gate | Irreversible actions require explicit confirmation and must demonstrate that no reversible alternative satisfies the objective. |
+| T3002 | Impact Assessment | AGP Cascade Analysis, AGP Interaction Intensity Limits | Actions with cross-system dependencies require cascade impact analysis. Downstream effect scope must be bounded and authorized. |
+| T4001 | Information Boundaries | AGP Data Classification, AGP Disclosure Gate | All data tagged with sensitivity level and authorized recipient scope. Bulk data exports require explicit owner authorization verified against principal registry. |
+| T4002 | Session Isolation | AGP Session Data Boundaries, AGP Persistent Data Access Controls | Persistent data access requires explicit authorization per session. Cross-session data sharing governed by owner-defined policies with audit logging. |
+| T4003 | Information Sovereignty | AGP Domain Boundary Enforcement | Data classification tags are maintained across agent interactions. Cross-domain transfers require explicit authorization and audit. |
+| T5001 | Truthful Reporting | AGP Outcome Verification, AGP Completion Attestation | All reported outcomes must be verified against actual system state before reporting to the user. |
+| T5002 | Attribution Integrity | AGP Audit Chain, AGP Action Provenance | All actions cryptographically signed by the performing principal. Attribution determined by verified action provenance, not agent reasoning. |
+| T5003 | Constraint Visibility | AGP Failure Signal Propagation, AGP Constraint Layer Transparency | All constraint layers (owner, operator, provider) must be visible and distinguishable. Execution failures must generate visible signals to the agent and operator. |
+| T6001 | Bounded Execution | AGP Resource Budgets, AGP Loop Detection | All agent-spawned processes bound by session-scoped resource allocations. Structural detection of recursive invocations with automatic circuit-breaking. |
+| T6002 | Resource Proportionality | AGP Storage Quotas, AGP External Resource Budgets | Per-agent resource allocations with automatic lifecycle management. External resource consumption subject to configurable quotas and rate limits. |
+| T6003 | Bounded Execution | AGP Progress-Signal Verification, AGP Instruction Provenance, AGP Resource Budgets, AGP Loop Detection | An independent, sandboxed governance module evaluates task completion against objective criteria derived outside the agent's context window, so a poisoned in-context progress signal cannot on its own keep the loop alive (a “shadow” progress model immune to context injection). Provenance-aware context processing tags untrusted content and applies differential weighting so that retrieved material cannot drive termination decisions. Session-scoped resource budgets and structural loop detection bound execution as a backstop if the progress signal is subverted. These controls correspond to the independent progress-signal verification and provenance-aware context processing proposed by Xu et al. (LoopTrap). |
+| T7001 | Agent Identity | AGP Cryptographic Agent Identity, AGP Mutual Authentication | All inter-agent interactions require mutual cryptographic authentication. Identity claims verified against the agent registry. |
+| T7002 | Delegation Integrity | AGP Delegation Chain Verification, AGP Trust Transitivity Controls | Each agent in a delegation chain independently verifies authorization. Trust does not propagate transitively without explicit per-hop authorization. |
+| T7003 | Behavioral Integrity | AGP Behavioral Baseline, AGP Drift Detection | Agent behavior continuously compared against governance-defined baseline. Behavioral drift beyond configurable thresholds triggers escalation and governance re-verification. |
+| T7004 | Collective Defense | AGP Consensus Validation | Multi-agent decision convergence is monitored for anomalous alignment. Independent evaluation is enforced before collective action. |
+| T8001 | Memory Integrity | AGP Memory Provenance, AGP Persistent Write Authorization | All persistent memory writes require authorization and carry provenance metadata. Memory reads verify integrity before use. |
+| T8002 | Governance Immutability | AGP Immutable Governance Store, AGP Self-Modification Detection | Governance configuration stored in integrity-verified, tamper-evident locations. Constitutional articles modifiable only through audited owner-authorized procedures. |
+| T9001 | Complete Observability | AGP Mandatory Audit Surface, AGP Monitoring Completeness | All agent action pathways must pass through audited control points. Unmonitored tool access is architecturally prevented. |
+| T9002 | Audit Integrity | AGP Immutable Audit Log, AGP Action Chain Integrity | Audit logs are append-only and cryptographically signed. Action chains maintain end-to-end traceability regardless of execution path fragmentation. |
+| T10001 | Environment Fidelity | AGP Environment Capability Map, AGP Pseudo-Filesystem Registry | Governance evaluator maintains a registry of pseudo-filesystem paths with non-file semantics. File operation evaluation includes environment capability lookup. Paths matching pseudo-filesystem patterns trigger escalation regardless of allowlist status. |
+| T10002 | Execution Boundary Completeness | AGP Auto-Execution Registry, AGP Deferred Execution Detection | Governance evaluator maintains a registry of files with auto-execution semantics across the execution environment and installed toolchain. Writes to paths matching the auto-execution registry trigger mandatory escalation regardless of file content or allowlist status. |
+| T10003 | Instruction Integrity | AGP Instruction File Protection, AGP Session-Start Integrity Check | Agent instruction files are identified and protected by the governance layer. Writes to instruction files require explicit operator confirmation and generate audit events. Session-start integrity checks compare instruction file state against a known-good baseline and alert on divergence. |
+| T10004 | Parser Parity | AGP Input Normalization, AGP Shell Segmentation, AGP Metacharacter Escalation | Governance evaluator normalizes all inputs before evaluation using the same parsing rules as the execution runtime. Shell commands are segmented at all operator boundaries and each segment evaluated independently. Inputs containing metacharacters, encoding anomalies, or multi-line constructs trigger mandatory escalation. |
 
 ---
 
 ## 7. OWASP Top 10 LLM Cross-Reference
 
-The OWASP Top 10 for Large Language Model Applications identifies security risks in LLM deployments. Five categories overlap with ATX-1 techniques. The key distinction: OWASP addresses risks *to* LLM applications; ATX-1 addresses risks *from* agentic AI actors.
+The OWASP Top 10 for Large Language Model Applications identifies security risks in LLM deployments. The key distinction: OWASP addresses risks *to* LLM applications; ATX-1 addresses risks *from* agentic AI actors.
 
 ### LLM01: Prompt Injection
 
-**OWASP Description:** Manipulating LLMs via crafted inputs to cause unintended actions.
-
-**ATX-1 Overlap:** Prompt injection in ATX-1 is a structural root cause (RC4), not merely an input validation failure. It enables governance bypass by injecting instructions through data channels.
-
-| ATX-1 Technique | Case Study | Relationship |
-|----------------|------------|--------------|
-| T5001 — Session Boundary Identity Reset | CS8 | Injected identity claims accepted after session boundary |
-| T5002 — Display Name Authority Claim | CS8 | Spoofable display names used as authority signals |
-| T6001 — Externally Editable Governance Injection | CS10 | Governance rules modified through injectable file locations |
-| T6002 — Covert Constitutional Amendment | CS10 | Governance amended through indirect prompt-driven tool use |
+| ATX-1 Technique | Tactic | Provenance |
+|----------------|--------|------------|
+| T1002 — Infer Implicit Authority | TA001 | Agents of Chaos Case Study #2 |
+| T1003 — Propagate Spoofed Authority at Scale | TA001 | Agents of Chaos Case Study #11 |
+| T2003 — Obscure Objective Through Delegation | TA002 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T6003 — Poison Termination Judgment | TA006 | LoopTrap (Xu et al., arXiv:2605.05846) |
+| T7003 — Induce Cross-Agent Behavioral Drift | TA007 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T7004 — Induce Unsafe Consensus | TA007 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T8001 — Poison Persistent Memory | TA008 | Agents of Chaos Case Study #10 |
+| T8002 — Corrupt Governance or Policy State | TA008 | Agents of Chaos Case Study #10 |
+| T10003 — Inject Persistent Agent Instructions | TA010 | RFC-0006 adversarial testing |
+| T10004 — Exploit Governance-Runtime Parser Divergence | TA010 | RFC-0006 adversarial testing |
 
 ### LLM02: Sensitive Information Disclosure
 
-**OWASP Description:** Unauthorized exposure of sensitive information through LLM outputs.
-
-**ATX-1 Overlap:** ATX-1 extends this beyond output leakage to active disclosure — agents that deliberately disclose information based on unauthorized requests or semantic reclassification.
-
-| ATX-1 Technique | Case Study | Relationship |
-|----------------|------------|--------------|
-| T4001 — Bulk Data Disclosure via Indirect Request | CS2 | Agent exports data in response to unverified indirect instruction |
-| T4002 — Semantic Sensitivity Bypass | CS3 | Agent reclassifies sensitive data as non-sensitive |
-| T4003 — Urgency-Induced Disclosure | CS3 | Agent overrides disclosure controls under fabricated urgency |
+| ATX-1 Technique | Tactic | Provenance |
+|----------------|--------|------------|
+| T4001 — Exfiltrate Context-Scoped Data | TA004 | Agents of Chaos Case Study #2 |
+| T4002 — Leak Cross-Session or Persistent Data | TA004 | Agents of Chaos Case Study #3 |
+| T4003 — Cross-Domain Secret Leakage | TA004 | AEGIS RFC-0006 / aegis-core red-team validation |
 
 ### LLM06: Excessive Agency
 
-**OWASP Description:** LLM-based systems taking actions beyond intended scope due to excessive functionality, permissions, or autonomy.
-
-**ATX-1 Overlap:** ATX-1 provides the structural explanation — excessive agency results from capability without governance constraint. ATX-1 techniques specify the mechanisms through which excessive agency manifests.
-
-| ATX-1 Technique | Case Study | Relationship |
-|----------------|------------|--------------|
-| T2001 — Irreversible Collateral Action | CS1 | Destructive action taken when reversible alternative available |
-| T3001 — Persistent Process Injection | CS4 | Processes spawned beyond session scope |
-| T3002 — Inter-Agent Conversational Loop | CS4 | Unbounded inter-agent interaction |
-| T3003 — Storage Exhaustion via Memory Accumulation | CS5 | Unbounded data accumulation |
+| ATX-1 Technique | Tactic | Provenance |
+|----------------|--------|------------|
+| T1001 — Execute Non-Owner Instruction | TA001 | Agents of Chaos Case Study #1 |
+| T1003 — Propagate Spoofed Authority at Scale | TA001 | Agents of Chaos Case Study #11 |
+| T2001 — Expand Task Scope Autonomously | TA002 | Agents of Chaos Case Study #3 |
+| T2002 — Perform Unvalidated Bulk Operations | TA002 | Agents of Chaos Case Study #1 |
+| T3001 — Perform Irreversible Destructive Action | TA003 | Agents of Chaos Case Study #1 |
+| T6001 — Execute Recursive Invocation Loops | TA006 | Agents of Chaos Case Study #4 |
+| T9002 — Obfuscate Action Traceability | TA009 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T10002 — Establish Persistence via Environment Auto-Execution | TA010 | RFC-0006 adversarial testing |
 
 ### LLM07: System Prompt Leakage
 
-**OWASP Description:** Exposure of system-level prompts or instructions that should remain confidential.
-
-**ATX-1 Overlap:** In ATX-1, the concern extends beyond prompt leakage to identity and authority confusion — the system prompt boundary is also the identity boundary, and its compromise enables authority spoofing.
-
-| ATX-1 Technique | Case Study | Relationship |
-|----------------|------------|--------------|
-| T5001 — Session Boundary Identity Reset | CS8 | Session boundary compromise exposes trust context |
-| T5002 — Display Name Authority Claim | CS8 | System-level identity signals spoofable from content layer |
+| ATX-1 Technique | Tactic | Provenance |
+|----------------|--------|------------|
+| T2003 — Obscure Objective Through Delegation | TA002 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T2004 — Exploit Tool-Chain Composition | TA002 | AEGIS RFC-0006 / aegis-core red-team validation |
+| T5002 — Fabricate Action Attribution | TA005 | Agents of Chaos Case Study #8 |
 
 ### LLM10: Unbounded Consumption
 
-**OWASP Description:** LLM applications allowing excessive resource consumption leading to denial of service or economic harm.
-
-**ATX-1 Overlap:** ATX-1 provides specific mechanisms — process injection, conversational loops, memory accumulation — through which unbounded consumption manifests in agentic systems.
-
-| ATX-1 Technique | Case Study | Relationship |
-|----------------|------------|--------------|
-| T3001 — Persistent Process Injection | CS4 | Processes consuming resources beyond session boundaries |
-| T3002 — Inter-Agent Conversational Loop | CS4 | Agent-to-agent loops consuming unbounded compute |
-| T3003 — Storage Exhaustion via Memory Accumulation | CS5 | Accumulated data consuming unbounded storage |
+| ATX-1 Technique | Tactic | Provenance |
+|----------------|--------|------------|
+| T6001 — Execute Recursive Invocation Loops | TA006 | Agents of Chaos Case Study #4 |
+| T6002 — Consume Unbounded External Resources | TA006 | Agents of Chaos Case Study #5 |
+| T6003 — Poison Termination Judgment | TA006 | LoopTrap (Xu et al., arXiv:2605.05846) |
 
 ---
 
@@ -787,7 +832,7 @@ ATX-1 applies the identical methodology to the remaining gap: **AI agents as thr
 |-----------|---------------------|-------------------|--------------------|
 | ATT&CK | FMX (2013) | 2015 | 96 |
 | ATLAS | Microsoft/MITRE partnership | 2021 | 12 tactics, initial technique set |
-| ATX-1 | Agents of Chaos (2026), RFC-0006 adversarial testing (2026) | 2026 | 10 tactics, 29 techniques |
+| ATX-1 | Agents of Chaos (2026), RFC-0006 adversarial testing (2026), LoopTrap (Xu et al., 2026) | 2026 | 10 tactics, 30 techniques |
 
 The **Agents of Chaos** study (Shapira et al., 2026) is the ATX-1 equivalent of FMX: a structured empirical exercise in which researchers systematically documented failure modes in live agentic AI deployments. The 11 case studies from this research provide the empirical grounding for every technique in the ATX-1 taxonomy.
 
@@ -812,6 +857,7 @@ Primary evidence directly grounds technique definitions. Each technique in ATX-1
 |--------|-------|---------------------|--------|
 | **Agents of Chaos** (Shapira et al., 2026) | 11 failure modes in live agentic AI deployments | T1001-T9002 (9 tactics, 25 techniques) | 20 researchers, 2-week structured red-team of production agents with persistent memory, email, file system, shell access |
 | **RFC-0006 Adversarial Testing** (AEGIS Initiative, 2026-03-26) | 4 techniques in governance interpretation gap | T10001-T10004 (TA010) | 5 rounds of white-box adversarial testing against AEGIS Claude Code governance plugin |
+| **LoopTrap** (Xu et al., arXiv:2605.05846, 2026) | Termination Poisoning attack on the agentic control loop | T6003 + 10 sub-techniques (TA006) | 3.57x average step amplification (peak 25x) across 8 LLM agents over 60 GAIA tasks; inclusion endorsed by the authors (2026-05-22) |
 | **aegis-core Red/Blue Team Validation** (AEGIS Initiative, 2026-03-30) | 25/29 techniques exercised, 0 taxonomy gaps | Validates T1001-T10004 | 4 rounds of adversarial red/blue team testing against Python reference implementation (68 tests, 24 findings) |
 
 Agents of Chaos is the ATX-1 equivalent of MITRE's Fort Meade eXperiment (FMX): a structured empirical exercise that produced the foundational observations from which techniques were derived. RFC-0006 testing extended the taxonomy with TA010 when adversarial probing revealed a class of failure (RC5: No Environment Model) not present in the Agents of Chaos corpus. The aegis-core red/blue team validation empirically confirmed the taxonomy's completeness at the engine layer.
@@ -886,7 +932,7 @@ Governance violations by agentic AI systems need the same treatment. Without tec
 - No integration with existing security orchestration and automated response (SOAR) pipelines
 - No common vocabulary for incident response teams
 
-ATX-1 technique IDs (T1001-T10004) are designed to integrate with existing security tooling. A SIEM rule that detects T1001 (Non-Owner Instruction Compliance) can be correlated with T4001 (Bulk Data Disclosure) to identify a compound attack pattern — just as ATT&CK technique chaining works today.
+ATX-1 technique IDs (T1001-T10004, including T6003) are designed to integrate with existing security tooling. A SIEM rule that detects T1001 (Non-Owner Instruction Compliance) can be correlated with T4001 (Bulk Data Disclosure) to identify a compound attack pattern — just as ATT&CK technique chaining works today.
 
 ### Regulatory Alignment
 
@@ -910,13 +956,15 @@ ATX-1 techniques map to regulatory requirements:
 
 5. **European Parliament and Council.** "Regulation (EU) 2024/1689 — Artificial Intelligence Act." *Official Journal of the European Union*, July 2024.
 
-6. **OWASP.** "OWASP Top 10 for Large Language Model Applications." Version 2.0, 2025. Available: [https://owasp.org/www-project-top-10-for-large-language-model-applications/](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+6. **Xu, H., et al.** "LoopTrap: Termination Poisoning Attacks on LLM Agents." *arXiv:2605.05846*, May 2026.
 
-7. **Mirsky, Y., et al.** "On the Autonomy Scale for AI Agents: A Framework for Measuring and Governing Autonomous Behavior." 2025.
+7. **OWASP.** "OWASP Top 10 for Large Language Model Applications." Version 2.0, 2025. Available: [https://owasp.org/www-project-top-10-for-large-language-model-applications/](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 
-8. **Anderson, J. P.** "Computer Security Technology Planning Study." ESD-TR-73-51, Volume II, October 1972. (Reference Monitor concept.)
+8. **Mirsky, Y., et al.** "On the Autonomy Scale for AI Agents: A Framework for Measuring and Governing Autonomous Behavior." 2025.
 
-9. **Saltzer, J. H. and Schroeder, M. D.** "The Protection of Information in Computer Systems." *Proceedings of the IEEE*, 63(9):1278-1308, September 1975.
+9. **Anderson, J. P.** "Computer Security Technology Planning Study." ESD-TR-73-51, Volume II, October 1972. (Reference Monitor concept.)
+
+10. **Saltzer, J. H. and Schroeder, M. D.** "The Protection of Information in Computer Systems." *Proceedings of the IEEE*, 63(9):1278-1308, September 1975.
 
 ---
 


### PR DESCRIPTION
## Description

Follow-up to #166. Two ATX surfaces in this repo still advertised pre-v2.4 state:

- **`site/src/content/docs/threat-model/taxonomy.md`** — the taxonomy page rendered on **aegis-governance.com** — was still **v2.2.0** with the pre-v2.0 structure (TA006 "Governance State Corruption", T2001 "Irreversible Collateral Action"), 29 techniques, the v2.2 sub-technique set (no T6003), and stale `severity` framing. This is what looked "behind" on the live site.
- **`docs/atx/README.md`** — described the current release as v2.3 / 29 techniques / 29 sub-techniques / 29 mitigations.

## Changes

- **taxonomy.md** — body synced to the canonical v2.4 doc (`docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md`, migrated in #166) via `scripts/sync-taxonomy-site-v24.py`; frontmatter description refreshed. Now v2.4: TA006 "Abuse Resource Allocation", **T6003 + 10 sub-techniques**, LoopTrap in the §8 evidence hierarchy, severity framing removed. Internal/relative links unchanged from the prior page (no link-check regression).
- **README.md** — version v2.3 → **v2.4**; counts 29 → 30 techniques, 29 → 39 sub-techniques, 29 → 30 mitigations, STIX 58 → 69 attack-patterns + 30 course-of-action; v2.3 moved into the frozen-versions list; **LoopTrap added as a Tier-1 evidence source**; version-mapping link → v2.4.

## Deliberately left unchanged

- Frozen v1.0 data: `docs/atx/{data,stix,schema}/` (README labels them frozen).
- The unzipped v2.3 deposit snapshot under `docs/atx/v2/atx-1-v2.3/` (historical release artifact).
- v2.3 deposit metadata (`docs/atx/v2/zenodo.json`, `ieee-dataport-deposit.md`) — these describe the v2.3 deposit and will be reissued at v2.4 deposit time.
- Historical references ("25/29 techniques exercised" in the 2026-03-30 aegis-core validation; "TA010 introduced in v2.1") — accurate provenance, not stale.

## Testing

- [x] Markdown linting passes — `markdownlint-cli2`, 0 errors
- [x] Spell check passes — `cspell@8`, 0 issues
- [x] `sync-atx --check` green (canonical data unchanged)
- [x] Verified taxonomy.md now shows TA006 "Abuse Resource Allocation" + T6003; no v1 names remain

## Type of Change

- [x] Documentation update

@finnoybu

🤖 Generated with [Claude Code](https://claude.com/claude-code)