### PR TITLE
docs: release notes for 2026-05-29

### DIFF
--- a/site/VERSION
+++ b/site/VERSION
@@ -1,5 +1,5 @@
 {
-  "tag": "v26.5.16",
-  "commit": "63edf5e",
-  "released_at": "2026-05-17T06:04:55Z"
+  "tag": "v26.5.29",
+  "commit": "c325ffb",
+  "released_at": "2026-05-30T06:05:13Z"
 }

--- a/site/src/content/docs/releases/26/5.md
+++ b/site/src/content/docs/releases/26/5.md
@@ -6,6 +6,15 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.5.29
+
+*Builds: b3350f0 – c325ffb* — [Development Log →](/releases/26/5/29/)
+
+- Added Termination Poisoning (T6003) to the ATX-1 taxonomy in version 2.4 (LoopTrap)
+- Updated the published taxonomy page and documentation to reflect ATX-1 v2.4 changes
+
+---
+
 ## Release / v26.5.16
 
 *Builds: c258ac3 – 63edf5e* — [Development Log →](/releases/26/5/16/)

--- a/site/src/content/docs/releases/26/5/29.md
+++ b/site/src/content/docs/releases/26/5/29.md
@@ -9,3 +9,4 @@ sidebar:
 ## Development Log
 
 - feat(atx-1): add Termination Poisoning T6003 — ATX-1 v2.4 (LoopTrap) (#166) (b3350f0)
+- fix(atx-1): bring published taxonomy page + README current to v2.4 (#167) (c325ffb)

--- a/site/src/content/docs/releases/26/5/29.md
+++ b/site/src/content/docs/releases/26/5/29.md
@@ -6,6 +6,14 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.5.29
+
+*Builds: b3350f0 – c325ffb*
+
+- Added Termination Poisoning (T6003) to the ATX-1 taxonomy in version 2.4 (LoopTrap)
+- Updated the published taxonomy page and documentation to reflect ATX-1 v2.4 changes
+
+---
 ## Development Log
 
 - feat(atx-1): add Termination Poisoning T6003 — ATX-1 v2.4 (LoopTrap) (#166) (b3350f0)

--- a/site/src/content/docs/releases/26/5/29.md
+++ b/site/src/content/docs/releases/26/5/29.md
@@ -1,0 +1,11 @@
+---
+title: "May 29, 2026"
+description: "Development log for May 29, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+- feat(atx-1): add Termination Poisoning T6003 — ATX-1 v2.4 (LoopTrap) (#166) (b3350f0)

--- a/site/src/content/docs/releases/index.md
+++ b/site/src/content/docs/releases/index.md
@@ -11,6 +11,7 @@ Release notes start in April 2026 with the introduction of the auto-release pipe
 
 ### [May](/releases/26/5/)
 
+- [v26.5.29](/releases/26/5/#release--v26529) — Added Termination Poisoning (T6003) to ATX-1 taxonomy v2.4
 - [v26.5.16](/releases/26/5/#release--v26516) — Fixed release index formatting and documentation linting issues
 - [v26.5.14](/releases/26/5/#release--v26514) — ATX-1 v2.3 manuscript revision with external validation and IEEE DataPort release
 - [v26.5.13](/releases/26/5/#release--v26513) — ATX-1 v2.3 taxonomy published with official DOI on Zenodo


### PR DESCRIPTION
Daily release rollup — dev log, monthly summary, and index update for 2026-05-29.