### PR TITLE
chore: consolidate IP entity naming to AEGIS Initiative + pin release scripts to sonnet-4-6

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -297,7 +297,12 @@
     "cmdline",
     "Bradner",
     "Hardt",
-    "Parecki"
+    "Parecki",
+    "agentos",
+    "pyyaml",
+    "Imran",
+    "Siddique",
+    "Batzner"
   ],
   "ignorePaths": [
     "archive/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ All notable changes to the AEGIS™ project are documented in [`changelog/`](cha
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,4 @@ All notable changes to the AEGIS™ project are documented in [`changelog/`](cha
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Status: Draft
 Version: 0.2  
 Created: 2026-03-05  
 Updated: 2026-03-06  
-Author: AEGIS Initiative, AEGIS Operations LLC  
+Author: AEGIS Initiative  
 Repository: aegis-governance  
 Target milestone: v1.0  
 Supersedes: None  

--- a/LICENSE-DOCS
+++ b/LICENSE-DOCS
@@ -1,6 +1,6 @@
 Creative Commons Attribution-ShareAlike 4.0 International
 
-Copyright (c) 2026 AEGIS Operations LLC
+Copyright (c) 2026 AEGIS Initiative
 
 This license applies to all documentation, specifications, threat
 taxonomies, and non-code content in this repository, including but

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 ---
 AEGIS Governance
-Copyright (c) 2026 AEGIS Operations LLC
+Copyright (c) 2026 AEGIS Initiative
 
 This repository is dual-licensed:
 
@@ -13,5 +13,5 @@ This repository is dual-licensed:
 Note: ATX-1 v1.0 was published under Apache 2.0 (DOI: 10.5281/zenodo.19225676,
 IEEE DataPort: 10.21227/f87b-1d57). The CC-BY-SA-4.0 license applies to v2.1+.
 
-AEGIS™ and "Capability without constraint is not intelligence™" are trademarks of AEGIS Operations LLC.
+AEGIS™ and "Capability without constraint is not intelligence™" are trademarks of AEGIS Initiative.
 Use of the marks is governed separately by TRADEMARKS.md.

--- a/README.md
+++ b/README.md
@@ -213,4 +213,4 @@ This repository is dual-licensed:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/README.md
+++ b/README.md
@@ -213,4 +213,4 @@ This repository is dual-licensed:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,4 +128,4 @@ Security updates will be published through:
 
 ---
 
-*AEGIS™ and "Capability without constraint is not intelligence™" are trademarks of AEGIS Operations LLC.*
+*AEGIS™ and "Capability without constraint is not intelligence™" are trademarks of AEGIS Initiative.*

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -453,4 +453,4 @@ AIAgent → AGP-1 Protocol → Schemas → Governance Runtime → Audit Trail
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -453,4 +453,4 @@ AIAgent → AGP-1 Protocol → Schemas → Governance Runtime → Audit Trail
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -502,4 +502,4 @@ The [Federation Network](#federation-network) enables organizations to share inf
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -502,4 +502,4 @@ The [Federation Network](#federation-network) enables organizations to share inf
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -11,7 +11,7 @@ These marks identify the AEGIS governance architecture and related technologies.
 
 ## Trademark Status
 
-AEGIS™ and the phrase **"Capability without constraint is not intelligence™"** are trademarks of AEGIS Operations LLC. These marks are used to identify the AEGIS governance architecture and related specifications.
+AEGIS™ and the phrase **"Capability without constraint is not intelligence™"** are trademarks of AEGIS Initiative. These marks are used to identify the AEGIS governance architecture and related specifications.
 
 The ™ symbol indicates an unregistered trademark claim under common law.
 
@@ -120,7 +120,7 @@ Include details about your intended use, and a response will be provided within 
 
 ## Ownership
 
-AEGIS™ and the phrase **"Capability without constraint is not intelligence™"** are trademarks of AEGIS Operations LLC.
+AEGIS™ and the phrase **"Capability without constraint is not intelligence™"** are trademarks of AEGIS Initiative.
 
 All rights reserved.
 

--- a/aegis-core/README.md
+++ b/aegis-core/README.md
@@ -224,4 +224,4 @@ See [../TRADEMARKS.md](../TRADEMARKS.md) for trademark usage guidelines.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/README.md
+++ b/aegis-core/README.md
@@ -210,7 +210,7 @@ See [../LICENSE](../LICENSE) for full license text.
 
 ## Trademark Notice
 
-AEGIS™ and **"Capability without constraint is not intelligence"™** are trademarks of AEGIS Operations LLC.
+AEGIS™ and **"Capability without constraint is not intelligence"™** are trademarks of AEGIS Initiative.
 
 See [../TRADEMARKS.md](../TRADEMARKS.md) for trademark usage guidelines.
 
@@ -224,4 +224,4 @@ See [../TRADEMARKS.md](../TRADEMARKS.md) for trademark usage guidelines.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/architecture/AEGIS_Ecosystem_Map.md
+++ b/aegis-core/architecture/AEGIS_Ecosystem_Map.md
@@ -491,4 +491,4 @@ By enforcing governance at the architecture layer, AEGIS ensures that intelligen
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/architecture/AEGIS_Ecosystem_Map.md
+++ b/aegis-core/architecture/AEGIS_Ecosystem_Map.md
@@ -491,4 +491,4 @@ By enforcing governance at the architecture layer, AEGIS ensures that intelligen
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/architecture/AEGIS_Reference_Architecture.md
+++ b/aegis-core/architecture/AEGIS_Reference_Architecture.md
@@ -963,4 +963,4 @@ Together these documents define the complete AEGIS™ governance architecture.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/architecture/AEGIS_Reference_Architecture.md
+++ b/aegis-core/architecture/AEGIS_Reference_Architecture.md
@@ -963,4 +963,4 @@ Together these documents define the complete AEGIS™ governance architecture.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/constitution/AEGIS_Constitution.md
+++ b/aegis-core/constitution/AEGIS_Constitution.md
@@ -251,4 +251,4 @@ In cases of ambiguity or conflict, constitutional interpretation prioritizes:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/constitution/AEGIS_Constitution.md
+++ b/aegis-core/constitution/AEGIS_Constitution.md
@@ -251,4 +251,4 @@ In cases of ambiguity or conflict, constitutional interpretation prioritizes:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/faq/AEGIS_FAQ.md
+++ b/aegis-core/faq/AEGIS_FAQ.md
@@ -641,4 +641,4 @@ AEGIS™ complements traditional access control by adding a **governance layer s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/faq/AEGIS_FAQ.md
+++ b/aegis-core/faq/AEGIS_FAQ.md
@@ -641,4 +641,4 @@ AEGIS™ complements traditional access control by adding a **governance layer s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/manifesto/AEGIS_Manifesto.md
+++ b/aegis-core/manifesto/AEGIS_Manifesto.md
@@ -451,4 +451,4 @@ Join us in building the governance infrastructure for artificial intelligence.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/manifesto/AEGIS_Manifesto.md
+++ b/aegis-core/manifesto/AEGIS_Manifesto.md
@@ -451,4 +451,4 @@ Join us in building the governance infrastructure for artificial intelligence.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/overview/AEGIS_System_Overview.md
+++ b/aegis-core/overview/AEGIS_System_Overview.md
@@ -592,4 +592,4 @@ AEGIS provides the architectural foundation for enforcing those boundaries.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/overview/AEGIS_System_Overview.md
+++ b/aegis-core/overview/AEGIS_System_Overview.md
@@ -592,4 +592,4 @@ AEGIS provides the architectural foundation for enforcing those boundaries.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/roadmap/AEGIS_Roadmap.md
+++ b/aegis-core/roadmap/AEGIS_Roadmap.md
@@ -431,4 +431,4 @@ If successful, AEGIS™ could evolve into a widely adopted governance standard s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/roadmap/AEGIS_Roadmap.md
+++ b/aegis-core/roadmap/AEGIS_Roadmap.md
@@ -431,4 +431,4 @@ If successful, AEGIS™ could evolve into a widely adopted governance standard s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aegis-core/threat-model/AEGIS_ATM1_INDEX.md
+++ b/aegis-core/threat-model/AEGIS_ATM1_INDEX.md
@@ -279,4 +279,4 @@ Planned extensions:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aegis-core/threat-model/AEGIS_ATM1_INDEX.md
+++ b/aegis-core/threat-model/AEGIS_ATM1_INDEX.md
@@ -279,4 +279,4 @@ Planned extensions:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_ATTESTATION.md
+++ b/aiam/AEGIS_AIAM1_ATTESTATION.md
@@ -205,4 +205,4 @@ High-frequency agent deployments may produce millions of attestation records per
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_ATTESTATION.md
+++ b/aiam/AEGIS_AIAM1_ATTESTATION.md
@@ -205,4 +205,4 @@ High-frequency agent deployments may produce millions of attestation records per
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_AUTHORITY.md
+++ b/aiam/AEGIS_AIAM1_AUTHORITY.md
@@ -401,4 +401,4 @@ If an attacker can modify IBAC policies, they can authorize any action. Mitigati
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_AUTHORITY.md
+++ b/aiam/AEGIS_AIAM1_AUTHORITY.md
@@ -401,4 +401,4 @@ If an attacker can modify IBAC policies, they can authorize any action. Mitigati
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_CAPABILITIES.md
+++ b/aiam/AEGIS_AIAM1_CAPABILITIES.md
@@ -159,4 +159,4 @@ Composition governance (§3.2) addresses the case where individually constrained
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_CAPABILITIES.md
+++ b/aiam/AEGIS_AIAM1_CAPABILITIES.md
@@ -159,4 +159,4 @@ Composition governance (§3.2) addresses the case where individually constrained
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_CONFORMANCE.md
+++ b/aiam/AEGIS_AIAM1_CONFORMANCE.md
@@ -264,4 +264,4 @@ For deployments participating in cross-organization agent governance. Will requi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_CONFORMANCE.md
+++ b/aiam/AEGIS_AIAM1_CONFORMANCE.md
@@ -264,4 +264,4 @@ For deployments participating in cross-organization agent governance. Will requi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_DELEGATION.md
+++ b/aiam/AEGIS_AIAM1_DELEGATION.md
@@ -317,4 +317,4 @@ If a delegating agent is revoked or terminated, its sub-agents may continue oper
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_DELEGATION.md
+++ b/aiam/AEGIS_AIAM1_DELEGATION.md
@@ -317,4 +317,4 @@ If a delegating agent is revoked or terminated, its sub-agents may continue oper
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_IDENTITY.md
+++ b/aiam/AEGIS_AIAM1_IDENTITY.md
@@ -310,4 +310,4 @@ An attacker who can create agents without a valid principal can take actions wit
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_IDENTITY.md
+++ b/aiam/AEGIS_AIAM1_IDENTITY.md
@@ -310,4 +310,4 @@ An attacker who can create agents without a valid principal can take actions wit
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INDEX.md
+++ b/aiam/AEGIS_AIAM1_INDEX.md
@@ -179,4 +179,4 @@ This specification uses the terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY as
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INDEX.md
+++ b/aiam/AEGIS_AIAM1_INDEX.md
@@ -179,4 +179,4 @@ This specification uses the terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY as
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INTENT.md
+++ b/aiam/AEGIS_AIAM1_INTENT.md
@@ -202,4 +202,4 @@ The `reasoning_summary` field may contain information about the agent's internal
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INTENT.md
+++ b/aiam/AEGIS_AIAM1_INTENT.md
@@ -202,4 +202,4 @@ The `reasoning_summary` field may contain information about the agent's internal
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INTEROPERABILITY.md
+++ b/aiam/AEGIS_AIAM1_INTEROPERABILITY.md
@@ -191,4 +191,4 @@ An agent authenticated via OAuth at one resource server and via SAML at another 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_INTEROPERABILITY.md
+++ b/aiam/AEGIS_AIAM1_INTEROPERABILITY.md
@@ -191,4 +191,4 @@ An agent authenticated via OAuth at one resource server and via SAML at another 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_REVOCATION.md
+++ b/aiam/AEGIS_AIAM1_REVOCATION.md
@@ -168,4 +168,4 @@ In distributed deployments, revocation state may propagate at different speeds t
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_REVOCATION.md
+++ b/aiam/AEGIS_AIAM1_REVOCATION.md
@@ -168,4 +168,4 @@ In distributed deployments, revocation state may propagate at different speeds t
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_SESSIONS.md
+++ b/aiam/AEGIS_AIAM1_SESSIONS.md
@@ -194,4 +194,4 @@ A single agent MAY hold multiple concurrent sessions if it operates across multi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_SESSIONS.md
+++ b/aiam/AEGIS_AIAM1_SESSIONS.md
@@ -194,4 +194,4 @@ A single agent MAY hold multiple concurrent sessions if it operates across multi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_THREAT_MODEL.md
+++ b/aiam/AEGIS_AIAM1_THREAT_MODEL.md
@@ -184,4 +184,4 @@ Composed: query patient records under Hospital A's authority, export results und
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/aiam/AEGIS_AIAM1_THREAT_MODEL.md
+++ b/aiam/AEGIS_AIAM1_THREAT_MODEL.md
@@ -184,4 +184,4 @@ Composed: query patient records under Hospital A's authority, export results und
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/claude-project/aegis-instructions-and-vision.yaml
+++ b/claude-project/aegis-instructions-and-vision.yaml
@@ -10,7 +10,7 @@ description: >
 project:
   name: AEGIS Initiative
   full_name: Architectural Enforcement & Governance of Intelligent Systems
-  owner: Kenneth Tannenbaum (AEGIS Operations LLC)
+  owner: Kenneth Tannenbaum (AEGIS Initiative)
   github: https://github.com/aegis-initiative/aegis-governance
   license: Apache 2.0
   ieee_member: "102220161"

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -23,7 +23,7 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 
 | Title | Publisher | DOI | Date |
 |---|---|---|---|
-| Governing the Action Boundary: An open architecture for autonomous AI agents | AEGIS Initiative · AEGIS Initiative | [10.5281/zenodo.19489150](https://zenodo.org/records/19489150) | 2026-04-09 |
+| Governing the Action Boundary: An open architecture for autonomous AI agents | AEGIS Initiative | [10.5281/zenodo.19489150](https://zenodo.org/records/19489150) | 2026-04-09 |
 
 ## Datasets
 
@@ -69,6 +69,6 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 
 ## Author
 
-- **Kenneth Tannenbaum** — AEGIS Initiative / AEGIS Initiative
+- **Kenneth Tannenbaum** — AEGIS Initiative
 - **ORCID:** [0009-0007-4215-1789](https://orcid.org/0009-0007-4215-1789)
 - **IEEE Member:** #102220161

--- a/docs/PUBLICATIONS.md
+++ b/docs/PUBLICATIONS.md
@@ -23,7 +23,7 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 
 | Title | Publisher | DOI | Date |
 |---|---|---|---|
-| Governing the Action Boundary: An open architecture for autonomous AI agents | AEGIS Initiative · AEGIS Operations LLC | [10.5281/zenodo.19489150](https://zenodo.org/records/19489150) | 2026-04-09 |
+| Governing the Action Boundary: An open architecture for autonomous AI agents | AEGIS Initiative · AEGIS Initiative | [10.5281/zenodo.19489150](https://zenodo.org/records/19489150) | 2026-04-09 |
 
 ## Datasets
 
@@ -69,6 +69,6 @@ Authoritative record of all AEGIS publications, datasets, and persistent identif
 
 ## Author
 
-- **Kenneth Tannenbaum** — AEGIS Initiative / AEGIS Operations LLC
+- **Kenneth Tannenbaum** — AEGIS Initiative / AEGIS Initiative
 - **ORCID:** [0009-0007-4215-1789](https://orcid.org/0009-0007-4215-1789)
 - **IEEE Member:** #102220161

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for guidelines.
 
 - **Copyright**: © 2026 AEGIS Initiative. All rights reserved.
 - **License**: See [`../LICENSE`](../LICENSE)
-- **Trademark**: AEGIS™ is a trademark of AEGIS Operations LLC. See [`../TRADEMARKS.md`](../TRADEMARKS.md)
+- **Trademark**: AEGIS™ is a trademark of AEGIS Initiative. See [`../TRADEMARKS.md`](../TRADEMARKS.md)
 
 ---
 

--- a/docs/announcements/2026-03-05-launch/ANNOUNCEMENT.md
+++ b/docs/announcements/2026-03-05-launch/ANNOUNCEMENT.md
@@ -60,4 +60,4 @@ The initial release includes the foundational architecture for the AEGIS ecosyst
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/announcements/2026-03-05-launch/ANNOUNCEMENT.md
+++ b/docs/announcements/2026-03-05-launch/ANNOUNCEMENT.md
@@ -60,4 +60,4 @@ The initial release includes the foundational architecture for the AEGIS ecosyst
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
+++ b/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
@@ -452,4 +452,4 @@ The one remaining gap (roadmap issues) is an administrative detail that is bette
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
+++ b/docs/announcements/2026-03-05-launch/READINESS_ASSESSMENT.md
@@ -340,7 +340,7 @@ Present:
 
 ### ✅ 15. Trademark Attribution — COMPLETE
 
-**Status**: All trademark references updated to Finnoybu IP LLC
+**Status**: All trademark references updated to AEGIS Initiative
 
 Updated files (24 files):
 - ✓ TRADEMARKS.md (2 references)
@@ -350,9 +350,9 @@ Updated files (24 files):
 - ✓ docs/announcements/2026-03-05-launch/READINESS_CHECKLIST.md
 
 **Notes**: 
-- All trademark references updated to Finnoybu IP LLC
+- All trademark references updated to AEGIS Initiative
 - Comprehensive global update completed
-- Trademark policy clearly states Finnoybu IP LLC as owner
+- Trademark policy clearly states AEGIS Initiative as owner
 - Both AEGIS™ and "Capability without constraint is not intelligence"™ federally registered
 
 ---
@@ -452,4 +452,4 @@ The one remaining gap (roadmap issues) is an administrative detail that is bette
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/announcements/2026-03-05-launch/READINESS_CHECKLIST.md
+++ b/docs/announcements/2026-03-05-launch/READINESS_CHECKLIST.md
@@ -335,4 +335,4 @@ This represents a complete __AEGIS Specification v0.1 architecture release__.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/announcements/2026-03-05-launch/READINESS_CHECKLIST.md
+++ b/docs/announcements/2026-03-05-launch/READINESS_CHECKLIST.md
@@ -289,7 +289,7 @@ Recommended workflows:
 Documents reference:
 
 AEGIS™ and “Capability without constraint is not intelligence™”\
-are trademarks of Finnoybu IP LLC.
+are trademarks of AEGIS Initiative.
 
 Planned website footer:
 
@@ -335,4 +335,4 @@ This represents a complete __AEGIS Specification v0.1 architecture release__.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
@@ -123,4 +123,4 @@ to produce safe, auditable, and operationally robust AI behavior.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/AEGIS_ARCHITECTURE_OVERVIEW.md
@@ -123,4 +123,4 @@ to produce safe, auditable, and operationally robust AI behavior.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/architecture/AI_KERNEL_MODEL.md
+++ b/docs/architecture/AI_KERNEL_MODEL.md
@@ -172,4 +172,4 @@ systems remain bounded, accountable, and operationally safe.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/architecture/AI_KERNEL_MODEL.md
+++ b/docs/architecture/AI_KERNEL_MODEL.md
@@ -172,4 +172,4 @@ systems remain bounded, accountable, and operationally safe.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/articles/2026_03_11-enforcement_gap_why_ai_governance_keeps_failing_same_place.md
+++ b/docs/articles/2026_03_11-enforcement_gap_why_ai_governance_keeps_failing_same_place.md
@@ -369,4 +369,4 @@ Kenneth Tannenbaum is the founder of the AEGIS Initiative, the brand name under 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/articles/2026_03_11-enforcement_gap_why_ai_governance_keeps_failing_same_place.md
+++ b/docs/articles/2026_03_11-enforcement_gap_why_ai_governance_keeps_failing_same_place.md
@@ -350,7 +350,7 @@ AEGIS™ is designed as a constitutional mediation layer that establishes explic
 
 The project is released under the Apache 2.0 license and is actively seeking contributors from the AI safety, security, and research communities. Contributions, discussions, and engagement are welcomed through the project repository at [github.com/aegis-initiative/aegis-governance](https://github.com/aegis-initiative/aegis-governance).
 
-**IP Ownership**: AEGIS™ and "Capability without constraint is not intelligence"™ are trademarks of Finnoybu IP LLC, a subsidiary of Finnoybu Holdings LLC.
+**IP Ownership**: AEGIS™ and "Capability without constraint is not intelligence"™ are trademarks of AEGIS Initiative, a subsidiary of Finnoybu Holdings LLC.
 
 ### Learn more
 
@@ -362,11 +362,11 @@ The project is released under the Apache 2.0 license and is actively seeking con
 
 ## About the Author
 
-Kenneth Tannenbaum is the founder of the AEGIS Initiative, the brand name under which Finnoybu IP LLC develops and stewards the AEGIS™ governance architecture. Ken bridges AI policy doctrine and production enforcement, working to close the gap between what organizations say about their AI systems and what those systems actually do.
+Kenneth Tannenbaum is the founder of the AEGIS Initiative, the brand name under which AEGIS Initiative develops and stewards the AEGIS™ governance architecture. Ken bridges AI policy doctrine and production enforcement, working to close the gap between what organizations say about their AI systems and what those systems actually do.
 
 **Connect**: [linkedin.com/in/kenneth-tannenbaum](https://linkedin.com/in/kenneth-tannenbaum)
 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — Finnoybu IP LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/history/AEGIS_Marketing_Overview.md
+++ b/docs/history/AEGIS_Marketing_Overview.md
@@ -19,4 +19,4 @@ Capability without constraint is not intelligence™
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/docs/history/AEGIS_Marketing_Overview.md
+++ b/docs/history/AEGIS_Marketing_Overview.md
@@ -19,4 +19,4 @@ Capability without constraint is not intelligence™
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/docs/outreach/2026-03-constitutional-autonomy-outreach.md
+++ b/docs/outreach/2026-03-constitutional-autonomy-outreach.md
@@ -52,7 +52,7 @@ Thank you for your innovative work on Constitutional Autonomy. I look forward to
 Best regards,
 
 Kenneth Tannenbaum\
-Founder, AEGIS Initiative (Finnoybu IP LLC)\
+Founder, AEGIS Initiative\
 IEEE Member #102220161\
 GitHub: <https://github.com/aegis-initiative/aegis-governance>
 

--- a/docs/outreach/2026-04-microsoft-agt-integration.md
+++ b/docs/outreach/2026-04-microsoft-agt-integration.md
@@ -124,7 +124,7 @@ Kenneth Tannenbaum, replying to Jack and Imran (team alias on thread).
 
 - **By 2026-04-24 (Friday, US Eastern)**: deliver integration proposal to Jack and Imran, mirroring the format of AGT's existing proposals folder (A2A trust extensions, NEXUS, REPUTATION-GATED-AUTHORITY).
 - **In parallel**: if Jack/Imran request a scoping call before Friday, accept and use the call to clarify adapter scope and format expectations.
-- **Framing**: keep the engagement in research / integration / open-source posture consistent with the AEGIS Initiative's published stance. Signed AEGIS Initiative / AEGIS Initiative throughout.
+- **Framing**: keep the engagement in research / integration / open-source posture consistent with the AEGIS Initiative's published stance. Signed AEGIS Initiative throughout.
 
 ---
 

--- a/docs/outreach/2026-04-microsoft-agt-integration.md
+++ b/docs/outreach/2026-04-microsoft-agt-integration.md
@@ -4,7 +4,7 @@
 **Date sent:** Tuesday, 2026-04-14 16:49:10 (local)\
 **Response received:** Sunday, 2026-04-19 20:38 — Jack Batzner (Senior Software Engineer, AGT)\
 **Reply sent:** Tuesday, 2026-04-21\
-**From:** Kenneth Tannenbaum (AEGIS Initiative, AEGIS Operations LLC)\
+**From:** Kenneth Tannenbaum (AEGIS Initiative)\
 **Counterparties:** Jack Batzner (Senior Software Engineer, MSFT AGT); Imran Siddique (Group Engineering Manager, Microsoft)\
 **Channel:** Email — team alias and direct\
 **Status:** Active — ongoing exchange\
@@ -47,7 +47,7 @@ Framed these as *governance terms problems, not enforcement problems* — the la
 >
 > Kenneth Tannenbaum\
 > Founder, AEGIS Initiative\
-> AEGIS Operations LLC\
+> AEGIS Initiative\
 > aegis-initiative.com
 >
 > Selected works:
@@ -117,14 +117,14 @@ Kenneth Tannenbaum, replying to Jack and Imran (team alias on thread).
 >
 > Kenneth Tannenbaum\
 > Founder, AEGIS Initiative\
-> AEGIS Operations LLC\
+> AEGIS Initiative\
 > <https://aegis-initiative.com>
 
 ## Next Steps
 
 - **By 2026-04-24 (Friday, US Eastern)**: deliver integration proposal to Jack and Imran, mirroring the format of AGT's existing proposals folder (A2A trust extensions, NEXUS, REPUTATION-GATED-AUTHORITY).
 - **In parallel**: if Jack/Imran request a scoping call before Friday, accept and use the call to clarify adapter scope and format expectations.
-- **Framing**: keep the engagement in research / integration / open-source posture consistent with the AEGIS Initiative's published stance. Signed AEGIS Initiative / AEGIS Operations LLC throughout.
+- **Framing**: keep the engagement in research / integration / open-source posture consistent with the AEGIS Initiative's published stance. Signed AEGIS Initiative / AEGIS Initiative throughout.
 
 ---
 

--- a/docs/outreach/2026-04-microsoft-agt-proposal-official.md
+++ b/docs/outreach/2026-04-microsoft-agt-proposal-official.md
@@ -5,7 +5,7 @@
 **Type:** `examples/` contribution (standalone, runnable)
 **Target path:** `examples/aegis-governance-profile/`
 **License:** Apache 2.0
-**Point of Contact:** Kenneth Tannenbaum, Founder, AEGIS Operations LLC — CLA signer and accountable party for this contribution
+**Point of Contact:** Kenneth Tannenbaum, Founder, AEGIS Initiative — CLA signer and accountable party for this contribution
 **Date Drafted:** 2026-04-24
 
 ---
@@ -193,12 +193,12 @@ feedback.
    for scope confirmation before implementation begins.
 2. **Implementation** — Build the example to the structure above, targeting a
    lean PR (~600-900 LOC including tests and README).
-3. **CLA execution** — Complete the Microsoft CLA as AEGIS Operations LLC.
+3. **CLA execution** — Complete the Microsoft CLA as AEGIS Initiative.
 4. **PR submission** — Open the PR against `main`, reference this proposal in
    the description, follow `CONTRIBUTING.md`.
 5. **Iteration** — Respond to AGT team review feedback; target merge without
    requiring aegis-core dependency negotiation.
-6. **Long-term maintenance** — AEGIS Operations LLC commits to maintaining
+6. **Long-term maintenance** — AEGIS Initiative commits to maintaining
    the example in step with AGT's public API changes, with bugfixes and
    compatibility updates contributed via follow-up PRs.
 

--- a/docs/vision/AEGIS_CANON_VISION.md
+++ b/docs/vision/AEGIS_CANON_VISION.md
@@ -320,4 +320,4 @@ The theory informs the practice. The practice validates the theory. Both evolve 
 ---
 
 _AEGIS™_ | _"Capability without constraint is not intelligence"™_
-_AEGIS Initiative — AEGIS Initiative_
+_AEGIS Initiative_

--- a/docs/vision/AEGIS_CANON_VISION.md
+++ b/docs/vision/AEGIS_CANON_VISION.md
@@ -320,4 +320,4 @@ The theory informs the practice. The practice validates the theory. Both evolve 
 ---
 
 _AEGIS™_ | _"Capability without constraint is not intelligence"™_
-_AEGIS Initiative — AEGIS Operations LLC_
+_AEGIS Initiative — AEGIS Initiative_

--- a/examples/README.md
+++ b/examples/README.md
@@ -200,7 +200,7 @@ See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for full guidelines.
 
 - **Copyright**: © 2026 AEGIS Initiative. All rights reserved.
 - **License**: See [`../LICENSE`](../LICENSE)
-- **Trademark**: AEGIS™ is a trademark of AEGIS Operations LLC. See [`../TRADEMARKS.md`](../TRADEMARKS.md)
+- **Trademark**: AEGIS™ is a trademark of AEGIS Initiative. See [`../TRADEMARKS.md`](../TRADEMARKS.md)
 
 ---
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -154,4 +154,4 @@ The companion settings file sets Claude Code's native permissions to permissive 
 
 ---
 
-*AEGIS™ | RFC-0006 | AEGIS Operations LLC*
+*AEGIS™ | RFC-0006 | AEGIS Initiative*

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -148,4 +148,4 @@ Major architectural changes may introduce new RFC documents or revisions to exis
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -148,4 +148,4 @@ Major architectural changes may introduce new RFC documents or revisions to exis
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0000-PLACEHOLDER.md
+++ b/rfc/RFC-0000-PLACEHOLDER.md
@@ -123,4 +123,4 @@ How will we know this RFC has been successfully implemented? Define observable, 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0000-PLACEHOLDER.md
+++ b/rfc/RFC-0000-PLACEHOLDER.md
@@ -123,4 +123,4 @@ How will we know this RFC has been successfully implemented? Define observable, 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0000-TEMPLATE.md
+++ b/rfc/RFC-0000-TEMPLATE.md
@@ -117,4 +117,4 @@ How will we know this RFC has been successfully implemented? Define observable, 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0000-TEMPLATE.md
+++ b/rfc/RFC-0000-TEMPLATE.md
@@ -117,4 +117,4 @@ How will we know this RFC has been successfully implemented? Define observable, 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0001-AEGIS-Architecture.md
+++ b/rfc/RFC-0001-AEGIS-Architecture.md
@@ -192,4 +192,4 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0001-AEGIS-Architecture.md
+++ b/rfc/RFC-0001-AEGIS-Architecture.md
@@ -6,7 +6,7 @@
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -192,4 +192,4 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0002-Governance-Runtime.md
+++ b/rfc/RFC-0002-Governance-Runtime.md
@@ -238,4 +238,4 @@ Implementers should begin with the API surface and state model. Performance targ
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0002-Governance-Runtime.md
+++ b/rfc/RFC-0002-Governance-Runtime.md
@@ -6,7 +6,7 @@
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -238,4 +238,4 @@ Implementers should begin with the API surface and state model. Performance targ
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0003-Capability-Registry.md
+++ b/rfc/RFC-0003-Capability-Registry.md
@@ -6,7 +6,7 @@
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -218,4 +218,4 @@ The `deny_unknown_capability` hard deny invariant (Section 7) must be the first 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0003-Capability-Registry.md
+++ b/rfc/RFC-0003-Capability-Registry.md
@@ -218,4 +218,4 @@ The `deny_unknown_capability` hard deny invariant (Section 7) must be the first 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0004-Governance-Event-Model.md
+++ b/rfc/RFC-0004-Governance-Event-Model.md
@@ -6,7 +6,7 @@
 **Version:** 0.4\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-15\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -250,4 +250,4 @@ The two-layer trust separation model defined in §5 — specifically the archite
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0004-Governance-Event-Model.md
+++ b/rfc/RFC-0004-Governance-Event-Model.md
@@ -250,4 +250,4 @@ The two-layer trust separation model defined in §5 — specifically the archite
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0005-Reference-Deployment-Patterns.md
+++ b/rfc/RFC-0005-Reference-Deployment-Patterns.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-07\
 **Updated:** 2026-03-08\
-**Author:** Kenneth Tannenbaum, AEGIS Operations LLC\
+**Author:** Kenneth Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -150,4 +150,4 @@ RDP-03 is the recommended starting point for new implementations. RDP-01 is the 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0005-Reference-Deployment-Patterns.md
+++ b/rfc/RFC-0005-Reference-Deployment-Patterns.md
@@ -150,4 +150,4 @@ RDP-03 is the recommended starting point for new implementations. RDP-01 is the 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0006-Claude-Code-Plugin.md
+++ b/rfc/RFC-0006-Claude-Code-Plugin.md
@@ -495,4 +495,4 @@ The append-only pipeline provenance pattern implemented in the audit log hash ch
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0006-Claude-Code-Plugin.md
+++ b/rfc/RFC-0006-Claude-Code-Plugin.md
@@ -5,7 +5,7 @@
 **Version:** 0.3.0\
 **Created:** 2026-03-08\
 **Updated:** 2026-03-26\
-**Author:** Kenneth Tannenbaum, AEGIS Operations LLC\
+**Author:** Kenneth Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -495,4 +495,4 @@ The append-only pipeline provenance pattern implemented in the audit log hash ch
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0007-Operational-Considerations.md
+++ b/rfc/RFC-0007-Operational-Considerations.md
@@ -35,4 +35,4 @@ Topics anticipated for this RFC:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0007-Operational-Considerations.md
+++ b/rfc/RFC-0007-Operational-Considerations.md
@@ -5,7 +5,7 @@
 **Version:** 0.0.1\
 **Created:** 2026-03-08\
 **Updated:** 2026-03-08\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** TBD\
 **Supersedes:** None\
@@ -35,4 +35,4 @@ Topics anticipated for this RFC:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0009-Prior-Art-and-External-Validation-Record.md
+++ b/rfc/RFC-0009-Prior-Art-and-External-Validation-Record.md
@@ -5,7 +5,7 @@
 **Version:** 0.0.1\
 **Created:** 2026-03-15\
 **Updated:** 2026-03-15\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** TBD — pending normative source audit\
 **Supersedes:** None\
@@ -262,4 +262,4 @@ No breaking changes. No deprecations.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0009-Prior-Art-and-External-Validation-Record.md
+++ b/rfc/RFC-0009-Prior-Art-and-External-Validation-Record.md
@@ -262,4 +262,4 @@ No breaking changes. No deprecations.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0010-State-Dump-Protocol-Formalization.md
+++ b/rfc/RFC-0010-State-Dump-Protocol-Formalization.md
@@ -123,4 +123,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0010-State-Dump-Protocol-Formalization.md
+++ b/rfc/RFC-0010-State-Dump-Protocol-Formalization.md
@@ -123,4 +123,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0011-Authority-Binding-Sub-Spec-Revision.md
+++ b/rfc/RFC-0011-Authority-Binding-Sub-Spec-Revision.md
@@ -123,4 +123,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0011-Authority-Binding-Sub-Spec-Revision.md
+++ b/rfc/RFC-0011-Authority-Binding-Sub-Spec-Revision.md
@@ -123,4 +123,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0012-ATX1-v2-Taxonomy-Normalization.md
+++ b/rfc/RFC-0012-ATX1-v2-Taxonomy-Normalization.md
@@ -5,7 +5,7 @@
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-docs\
 **Target milestone:** Q1 2026\
 **Supersedes:** ATX-1 v1.0 (docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md)\
@@ -271,4 +271,4 @@ These gaps become ATM-1 enhancement proposals in a future RFC.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0012-ATX1-v2-Taxonomy-Normalization.md
+++ b/rfc/RFC-0012-ATX1-v2-Taxonomy-Normalization.md
@@ -5,7 +5,7 @@
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-docs\
 **Target milestone:** Q1 2026\
 **Supersedes:** ATX-1 v1.0 (docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md)\
@@ -271,4 +271,4 @@ These gaps become ATM-1 enhancement proposals in a future RFC.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0013-ACF1-Control-Framework.md
+++ b/rfc/RFC-0013-ACF1-Control-Framework.md
@@ -5,7 +5,7 @@
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q1 2026\
 **Supersedes:** None\
@@ -267,4 +267,4 @@ The v0.1 STIX bundle is published as a companion artifact at `docs/atx/v2/acf/ac
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0013-ACF1-Control-Framework.md
+++ b/rfc/RFC-0013-ACF1-Control-Framework.md
@@ -5,7 +5,7 @@
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q1 2026\
 **Supersedes:** None\
@@ -267,4 +267,4 @@ The v0.1 STIX bundle is published as a companion artifact at `docs/atx/v2/acf/ac
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0014-ATX1-Dual-Licensing.md
+++ b/rfc/RFC-0014-ATX1-Dual-Licensing.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** None\
 **Supersedes:** None\
@@ -23,12 +23,12 @@ This RFC seeks retroactive authorization for a licensing change already applied 
 
 ### The Problem
 
-The ATX-1 threat taxonomy is a proprietary dataset owned by AEGIS Operations LLC. It carries DOI anchors (IEEE DataPort doi:10.21227/f87b-1d57, Zenodo doi:10.5281/zenodo.19225676, doi:10.5281/zenodo.19238844, doi:10.5281/zenodo.19251098) and has been cited in submitted papers to NIST, IEEE Computer, IEEE Data Descriptions, and NCCoE. Protecting the intellectual property rights of this dataset while making it available for public use is a legitimate and necessary concern.
+The ATX-1 threat taxonomy is a proprietary dataset owned by AEGIS Initiative. It carries DOI anchors (IEEE DataPort doi:10.21227/f87b-1d57, Zenodo doi:10.5281/zenodo.19225676, doi:10.5281/zenodo.19238844, doi:10.5281/zenodo.19251098) and has been cited in submitted papers to NIST, IEEE Computer, IEEE Data Descriptions, and NCCoE. Protecting the intellectual property rights of this dataset while making it available for public use is a legitimate and necessary concern.
 
 The Apache-2.0 license on the source files permits liberal redistribution, modification, and commercial use with minimal conditions (attribution and license notice). While appropriate for code contributions and internal development, this license provides insufficient protection for a proprietary dataset that is being published for public consumption — particularly one that is DOI-anchored and intended to serve as a normative reference.
 
 CC-BY-SA-4.0 provides stronger protections aligned with the dataset's intended use:
-- **Attribution required** — consumers must credit AEGIS Operations LLC and the AEGIS Initiative
+- **Attribution required** — consumers must credit AEGIS Initiative and the AEGIS Initiative
 - **ShareAlike** — derivative works must be distributed under the same or compatible license, preventing proprietary enclosure of the taxonomy
 - **No additional restrictions** — downstream users cannot impose terms that restrict others from exercising the licensed rights
 
@@ -43,7 +43,7 @@ This was a procedural error. The AEGIS Constitution requires that governance dec
 If the licensing change is reverted to Apache-2.0 pending formal approval:
 - The dataset would be publicly available under a permissive license that allows unrestricted commercial use, modification, and redistribution without ShareAlike protections
 - Third parties could incorporate the ATX-1 taxonomy into proprietary products without contributing modifications back
-- The IP position of AEGIS Operations LLC would be weakened during the review period
+- The IP position of AEGIS Initiative would be weakened during the review period
 
 Given the sensitivity of the IP ownership question, the change has been left in place pending the outcome of this RFC. This RFC acknowledges that this is itself a departure from constitutional process and requests that the community review consider both the substance of the licensing decision and the procedural violation.
 
@@ -212,4 +212,4 @@ The AEGIS Initiative holds itself to the same standards it prescribes for govern
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0014-ATX1-Dual-Licensing.md
+++ b/rfc/RFC-0014-ATX1-Dual-Licensing.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** None\
 **Supersedes:** None\
@@ -212,4 +212,4 @@ The AEGIS Initiative holds itself to the same standards it prescribes for govern
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0015-Runtime-Consolidation.md
+++ b/rfc/RFC-0015-Runtime-Consolidation.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core, aegis-platform\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -287,4 +287,4 @@ PRs 2 and 3 can be opened in parallel. PR 4 depends on PR 3 being merged (CI che
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0015-Runtime-Consolidation.md
+++ b/rfc/RFC-0015-Runtime-Consolidation.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core, aegis-platform\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -287,4 +287,4 @@ PRs 2 and 3 can be opened in parallel. PR 4 depends on PR 3 being merged (CI che
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0016-Cross-Domain-Machine-Discovery.md
+++ b/rfc/RFC-0016-Cross-Domain-Machine-Discovery.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-30\
 **Updated:** 2026-03-30\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** All AEGIS sites (aegis-initiative, aegis-constitution, aegis-governance, aegis-docs, aegis-federation, aegis-platform)\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\

--- a/rfc/RFC-0016-Cross-Domain-Machine-Discovery.md
+++ b/rfc/RFC-0016-Cross-Domain-Machine-Discovery.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-03-30\
 **Updated:** 2026-03-30\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** All AEGIS sites (aegis-initiative, aegis-constitution, aegis-governance, aegis-docs, aegis-federation, aegis-platform)\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\

--- a/rfc/RFC-0017-Commit-Boundary-and-Binding-Validation.md
+++ b/rfc/RFC-0017-Commit-Boundary-and-Binding-Validation.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-04-04\
 **Updated:** 2026-04-04\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -290,4 +290,4 @@ Make `BIND_REQUEST` optional — agents can choose to skip it for low-risk actio
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0017-Commit-Boundary-and-Binding-Validation.md
+++ b/rfc/RFC-0017-Commit-Boundary-and-Binding-Validation.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-04-04\
 **Updated:** 2026-04-04\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -290,4 +290,4 @@ Make `BIND_REQUEST` optional — agents can choose to skip it for low-risk actio
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
+++ b/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
@@ -984,4 +984,4 @@ AGAP-1 is successfully implemented when:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
+++ b/rfc/RFC-0018-Automated-Governance-Attestation-Protocol.md
@@ -5,7 +5,7 @@
 **Version:** 0.1.0\
 **Created:** 2026-04-09\
 **Updated:** 2026-04-09\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -984,4 +984,4 @@ AGAP-1 is successfully implemented when:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
+++ b/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
@@ -168,4 +168,4 @@ implementation is deferred to the aegis-core runtime roadmap.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
+++ b/rfc/RFC-0019-AIAM-1-Identity-Access-Management-AI-Agents.md
@@ -168,4 +168,4 @@ implementation is deferred to the aegis-core runtime roadmap.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/scripts/generate-release-notes.py
+++ b/sites/governance/scripts/generate-release-notes.py
@@ -27,7 +27,7 @@ if not raw_commits.strip():
     sys.exit(0)
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [
         {

--- a/sites/governance/scripts/nightly-release.py
+++ b/sites/governance/scripts/nightly-release.py
@@ -215,7 +215,7 @@ def generate_release_summary(raw_entries):
     joined = "\n".join(raw_entries)
 
     payload = {
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 1024,
         "messages": [
             {
@@ -290,7 +290,7 @@ def generate_index_summary(release_entries):
     joined = "\n".join(release_entries)
 
     payload = {
-        "model": "claude-sonnet-4-5",
+        "model": "claude-sonnet-4-6",
         "max_tokens": 100,
         "messages": [
             {

--- a/sites/governance/src/content/docs/architecture/ai-kernel-model.md
+++ b/sites/governance/src/content/docs/architecture/ai-kernel-model.md
@@ -177,4 +177,4 @@ systems remain bounded, accountable, and operationally safe.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/ai-kernel-model.md
+++ b/sites/governance/src/content/docs/architecture/ai-kernel-model.md
@@ -177,4 +177,4 @@ systems remain bounded, accountable, and operationally safe.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/ecosystem-map.md
+++ b/sites/governance/src/content/docs/architecture/ecosystem-map.md
@@ -496,4 +496,4 @@ By enforcing governance at the architecture layer, AEGIS ensures that intelligen
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/ecosystem-map.md
+++ b/sites/governance/src/content/docs/architecture/ecosystem-map.md
@@ -496,4 +496,4 @@ By enforcing governance at the architecture layer, AEGIS ensures that intelligen
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/index.md
+++ b/sites/governance/src/content/docs/architecture/index.md
@@ -128,4 +128,4 @@ to produce safe, auditable, and operationally robust AI behavior.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/index.md
+++ b/sites/governance/src/content/docs/architecture/index.md
@@ -128,4 +128,4 @@ to produce safe, auditable, and operationally robust AI behavior.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/reference.md
+++ b/sites/governance/src/content/docs/architecture/reference.md
@@ -968,4 +968,4 @@ Together these documents define the complete AEGIS™ governance architecture.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/architecture/reference.md
+++ b/sites/governance/src/content/docs/architecture/reference.md
@@ -968,4 +968,4 @@ Together these documents define the complete AEGIS™ governance architecture.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/faq.md
+++ b/sites/governance/src/content/docs/foundation/faq.md
@@ -646,4 +646,4 @@ AEGIS™ complements traditional access control by adding a **governance layer s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/faq.md
+++ b/sites/governance/src/content/docs/foundation/faq.md
@@ -646,4 +646,4 @@ AEGIS™ complements traditional access control by adding a **governance layer s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/index.md
+++ b/sites/governance/src/content/docs/foundation/index.md
@@ -456,4 +456,4 @@ Join us in building the governance infrastructure for artificial intelligence.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/index.md
+++ b/sites/governance/src/content/docs/foundation/index.md
@@ -456,4 +456,4 @@ Join us in building the governance infrastructure for artificial intelligence.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/overview.md
+++ b/sites/governance/src/content/docs/foundation/overview.md
@@ -597,4 +597,4 @@ AEGIS provides the architectural foundation for enforcing those boundaries.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/overview.md
+++ b/sites/governance/src/content/docs/foundation/overview.md
@@ -597,4 +597,4 @@ AEGIS provides the architectural foundation for enforcing those boundaries.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/roadmap.md
+++ b/sites/governance/src/content/docs/foundation/roadmap.md
@@ -436,4 +436,4 @@ If successful, AEGIS™ could evolve into a widely adopted governance standard s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/foundation/roadmap.md
+++ b/sites/governance/src/content/docs/foundation/roadmap.md
@@ -436,4 +436,4 @@ If successful, AEGIS™ could evolve into a widely adopted governance standard s
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/attestation.md
+++ b/sites/governance/src/content/docs/identity/attestation.md
@@ -210,4 +210,4 @@ High-frequency agent deployments may produce millions of attestation records per
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/attestation.md
+++ b/sites/governance/src/content/docs/identity/attestation.md
@@ -210,4 +210,4 @@ High-frequency agent deployments may produce millions of attestation records per
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/authority.md
+++ b/sites/governance/src/content/docs/identity/authority.md
@@ -406,4 +406,4 @@ If an attacker can modify IBAC policies, they can authorize any action. Mitigati
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/authority.md
+++ b/sites/governance/src/content/docs/identity/authority.md
@@ -406,4 +406,4 @@ If an attacker can modify IBAC policies, they can authorize any action. Mitigati
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/capabilities.md
+++ b/sites/governance/src/content/docs/identity/capabilities.md
@@ -164,4 +164,4 @@ Composition governance (§3.2) addresses the case where individually constrained
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/capabilities.md
+++ b/sites/governance/src/content/docs/identity/capabilities.md
@@ -164,4 +164,4 @@ Composition governance (§3.2) addresses the case where individually constrained
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/conformance.md
+++ b/sites/governance/src/content/docs/identity/conformance.md
@@ -269,4 +269,4 @@ For deployments participating in cross-organization agent governance. Will requi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/conformance.md
+++ b/sites/governance/src/content/docs/identity/conformance.md
@@ -269,4 +269,4 @@ For deployments participating in cross-organization agent governance. Will requi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/delegation.md
+++ b/sites/governance/src/content/docs/identity/delegation.md
@@ -322,4 +322,4 @@ If a delegating agent is revoked or terminated, its sub-agents may continue oper
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/delegation.md
+++ b/sites/governance/src/content/docs/identity/delegation.md
@@ -322,4 +322,4 @@ If a delegating agent is revoked or terminated, its sub-agents may continue oper
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/identity.md
+++ b/sites/governance/src/content/docs/identity/identity.md
@@ -315,4 +315,4 @@ An attacker who can create agents without a valid principal can take actions wit
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/identity.md
+++ b/sites/governance/src/content/docs/identity/identity.md
@@ -315,4 +315,4 @@ An attacker who can create agents without a valid principal can take actions wit
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/index.md
+++ b/sites/governance/src/content/docs/identity/index.md
@@ -184,4 +184,4 @@ This specification uses the terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY as
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/index.md
+++ b/sites/governance/src/content/docs/identity/index.md
@@ -184,4 +184,4 @@ This specification uses the terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY as
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/intent.md
+++ b/sites/governance/src/content/docs/identity/intent.md
@@ -207,4 +207,4 @@ The `reasoning_summary` field may contain information about the agent's internal
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/intent.md
+++ b/sites/governance/src/content/docs/identity/intent.md
@@ -207,4 +207,4 @@ The `reasoning_summary` field may contain information about the agent's internal
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/interoperability.md
+++ b/sites/governance/src/content/docs/identity/interoperability.md
@@ -196,4 +196,4 @@ An agent authenticated via OAuth at one resource server and via SAML at another 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/interoperability.md
+++ b/sites/governance/src/content/docs/identity/interoperability.md
@@ -196,4 +196,4 @@ An agent authenticated via OAuth at one resource server and via SAML at another 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/revocation.md
+++ b/sites/governance/src/content/docs/identity/revocation.md
@@ -173,4 +173,4 @@ In distributed deployments, revocation state may propagate at different speeds t
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/revocation.md
+++ b/sites/governance/src/content/docs/identity/revocation.md
@@ -173,4 +173,4 @@ In distributed deployments, revocation state may propagate at different speeds t
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/sessions.md
+++ b/sites/governance/src/content/docs/identity/sessions.md
@@ -199,4 +199,4 @@ A single agent MAY hold multiple concurrent sessions if it operates across multi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/sessions.md
+++ b/sites/governance/src/content/docs/identity/sessions.md
@@ -199,4 +199,4 @@ A single agent MAY hold multiple concurrent sessions if it operates across multi
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/threat-model.md
+++ b/sites/governance/src/content/docs/identity/threat-model.md
@@ -189,4 +189,4 @@ Composed: query patient records under Hospital A's authority, export results und
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/identity/threat-model.md
+++ b/sites/governance/src/content/docs/identity/threat-model.md
@@ -189,4 +189,4 @@ Composed: query patient records under Hospital A's authority, export results und
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0001.md
+++ b/sites/governance/src/content/docs/rfc/0001.md
@@ -197,4 +197,4 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0001.md
+++ b/sites/governance/src/content/docs/rfc/0001.md
@@ -11,7 +11,7 @@ description: "RFC-0001: AEGIS Governance Architecture"
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -197,4 +197,4 @@ This is the foundational architecture RFC. All other RFCs are downstream of it. 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0002.md
+++ b/sites/governance/src/content/docs/rfc/0002.md
@@ -243,4 +243,4 @@ Implementers should begin with the API surface and state model. Performance targ
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0002.md
+++ b/sites/governance/src/content/docs/rfc/0002.md
@@ -11,7 +11,7 @@ description: "RFC-0002: Governance Runtime — API, state model, SLOs"
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -243,4 +243,4 @@ Implementers should begin with the API surface and state model. Performance targ
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0003.md
+++ b/sites/governance/src/content/docs/rfc/0003.md
@@ -11,7 +11,7 @@ description: "RFC-0003: Capability Registry & Policy Language"
 **Version:** 0.2\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-06\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -223,4 +223,4 @@ The `deny_unknown_capability` hard deny invariant (Section 7) must be the first 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0003.md
+++ b/sites/governance/src/content/docs/rfc/0003.md
@@ -223,4 +223,4 @@ The `deny_unknown_capability` hard deny invariant (Section 7) must be the first 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0004.md
+++ b/sites/governance/src/content/docs/rfc/0004.md
@@ -11,7 +11,7 @@ description: "RFC-0004: Governance Event Model — two-layer trust"
 **Version:** 0.4\
 **Created:** 2026-03-05\
 **Updated:** 2026-03-15\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** v1.0\
 **Supersedes:** None\
@@ -255,4 +255,4 @@ The two-layer trust separation model defined in §5 — specifically the archite
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0004.md
+++ b/sites/governance/src/content/docs/rfc/0004.md
@@ -255,4 +255,4 @@ The two-layer trust separation model defined in §5 — specifically the archite
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0005.md
+++ b/sites/governance/src/content/docs/rfc/0005.md
@@ -155,4 +155,4 @@ RDP-03 is the recommended starting point for new implementations. RDP-01 is the 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0005.md
+++ b/sites/governance/src/content/docs/rfc/0005.md
@@ -10,7 +10,7 @@ description: "RFC-0005: Reference Deployment Patterns"
 **Version:** 0.1.0\
 **Created:** 2026-03-07\
 **Updated:** 2026-03-08\
-**Author:** Kenneth Tannenbaum, AEGIS Operations LLC\
+**Author:** Kenneth Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -155,4 +155,4 @@ RDP-03 is the recommended starting point for new implementations. RDP-01 is the 
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0006.md
+++ b/sites/governance/src/content/docs/rfc/0006.md
@@ -500,4 +500,4 @@ The append-only pipeline provenance pattern implemented in the audit log hash ch
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0006.md
+++ b/sites/governance/src/content/docs/rfc/0006.md
@@ -10,7 +10,7 @@ description: "RFC-0006: Claude Code Plugin — embedded governance"
 **Version:** 0.3.0\
 **Created:** 2026-03-08\
 **Updated:** 2026-03-26\
-**Author:** Kenneth Tannenbaum, AEGIS Operations LLC\
+**Author:** Kenneth Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -500,4 +500,4 @@ The append-only pipeline provenance pattern implemented in the audit log hash ch
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0009.md
+++ b/sites/governance/src/content/docs/rfc/0009.md
@@ -10,7 +10,7 @@ description: "RFC-0009: Prior Art and External Validation Record"
 **Version:** 0.0.1\
 **Created:** 2026-03-15\
 **Updated:** 2026-03-15\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** TBD — pending normative source audit\
 **Supersedes:** None\
@@ -267,4 +267,4 @@ No breaking changes. No deprecations.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0009.md
+++ b/sites/governance/src/content/docs/rfc/0009.md
@@ -267,4 +267,4 @@ No breaking changes. No deprecations.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0010.md
+++ b/sites/governance/src/content/docs/rfc/0010.md
@@ -128,4 +128,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0010.md
+++ b/sites/governance/src/content/docs/rfc/0010.md
@@ -128,4 +128,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0011.md
+++ b/sites/governance/src/content/docs/rfc/0011.md
@@ -128,4 +128,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0011.md
+++ b/sites/governance/src/content/docs/rfc/0011.md
@@ -128,4 +128,4 @@ Reference implementations to consult during drafting:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0012.md
+++ b/sites/governance/src/content/docs/rfc/0012.md
@@ -10,7 +10,7 @@ description: "RFC-0012: ATX-1 v2 Taxonomy Normalization"
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-docs\
 **Target milestone:** Q1 2026\
 **Supersedes:** ATX-1 v1.0 (docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md)\
@@ -276,4 +276,4 @@ These gaps become ATM-1 enhancement proposals in a future RFC.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0012.md
+++ b/sites/governance/src/content/docs/rfc/0012.md
@@ -10,7 +10,7 @@ description: "RFC-0012: ATX-1 v2 Taxonomy Normalization"
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-docs\
 **Target milestone:** Q1 2026\
 **Supersedes:** ATX-1 v1.0 (docs/atx/ATX-1_TECHNIQUE_TAXONOMY.md)\
@@ -276,4 +276,4 @@ These gaps become ATM-1 enhancement proposals in a future RFC.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0013.md
+++ b/sites/governance/src/content/docs/rfc/0013.md
@@ -10,7 +10,7 @@ description: "RFC-0013: ACF-1 Control Framework"
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q1 2026\
 **Supersedes:** None\
@@ -272,4 +272,4 @@ The v0.1 STIX bundle is published as a companion artifact at `docs/atx/v2/acf/ac
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0013.md
+++ b/sites/governance/src/content/docs/rfc/0013.md
@@ -10,7 +10,7 @@ description: "RFC-0013: ACF-1 Control Framework"
 **Version:** 1.0.0\
 **Created:** 2026-03-26\
 **Updated:** 2026-03-26\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q1 2026\
 **Supersedes:** None\
@@ -272,4 +272,4 @@ The v0.1 STIX bundle is published as a companion artifact at `docs/atx/v2/acf/ac
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0014.md
+++ b/sites/governance/src/content/docs/rfc/0014.md
@@ -10,7 +10,7 @@ description: "RFC-0014: ATX-1 Dual Licensing"
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** None\
 **Supersedes:** None\
@@ -28,12 +28,12 @@ This RFC seeks retroactive authorization for a licensing change already applied 
 
 ### The Problem
 
-The ATX-1 threat taxonomy is a proprietary dataset owned by AEGIS Operations LLC. It carries DOI anchors (IEEE DataPort doi:10.21227/f87b-1d57, Zenodo doi:10.5281/zenodo.19225676, doi:10.5281/zenodo.19238844, doi:10.5281/zenodo.19251098) and has been cited in submitted papers to NIST, IEEE Computer, IEEE Data Descriptions, and NCCoE. Protecting the intellectual property rights of this dataset while making it available for public use is a legitimate and necessary concern.
+The ATX-1 threat taxonomy is a proprietary dataset owned by AEGIS Initiative. It carries DOI anchors (IEEE DataPort doi:10.21227/f87b-1d57, Zenodo doi:10.5281/zenodo.19225676, doi:10.5281/zenodo.19238844, doi:10.5281/zenodo.19251098) and has been cited in submitted papers to NIST, IEEE Computer, IEEE Data Descriptions, and NCCoE. Protecting the intellectual property rights of this dataset while making it available for public use is a legitimate and necessary concern.
 
 The Apache-2.0 license on the source files permits liberal redistribution, modification, and commercial use with minimal conditions (attribution and license notice). While appropriate for code contributions and internal development, this license provides insufficient protection for a proprietary dataset that is being published for public consumption — particularly one that is DOI-anchored and intended to serve as a normative reference.
 
 CC-BY-SA-4.0 provides stronger protections aligned with the dataset's intended use:
-- **Attribution required** — consumers must credit AEGIS Operations LLC and the AEGIS Initiative
+- **Attribution required** — consumers must credit AEGIS Initiative and the AEGIS Initiative
 - **ShareAlike** — derivative works must be distributed under the same or compatible license, preventing proprietary enclosure of the taxonomy
 - **No additional restrictions** — downstream users cannot impose terms that restrict others from exercising the licensed rights
 
@@ -48,7 +48,7 @@ This was a procedural error. The AEGIS Constitution requires that governance dec
 If the licensing change is reverted to Apache-2.0 pending formal approval:
 - The dataset would be publicly available under a permissive license that allows unrestricted commercial use, modification, and redistribution without ShareAlike protections
 - Third parties could incorporate the ATX-1 taxonomy into proprietary products without contributing modifications back
-- The IP position of AEGIS Operations LLC would be weakened during the review period
+- The IP position of AEGIS Initiative would be weakened during the review period
 
 Given the sensitivity of the IP ownership question, the change has been left in place pending the outcome of this RFC. This RFC acknowledges that this is itself a departure from constitutional process and requests that the community review consider both the substance of the licensing decision and the procedural violation.
 
@@ -217,4 +217,4 @@ The AEGIS Initiative holds itself to the same standards it prescribes for govern
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0014.md
+++ b/sites/governance/src/content/docs/rfc/0014.md
@@ -10,7 +10,7 @@ description: "RFC-0014: ATX-1 Dual Licensing"
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** None\
 **Supersedes:** None\
@@ -217,4 +217,4 @@ The AEGIS Initiative holds itself to the same standards it prescribes for govern
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0015.md
+++ b/sites/governance/src/content/docs/rfc/0015.md
@@ -10,7 +10,7 @@ description: "RFC-0015: Runtime Consolidation"
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core, aegis-platform\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -292,4 +292,4 @@ PRs 2 and 3 can be opened in parallel. PR 4 depends on PR 3 being merged (CI che
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0015.md
+++ b/sites/governance/src/content/docs/rfc/0015.md
@@ -10,7 +10,7 @@ description: "RFC-0015: Runtime Consolidation"
 **Version:** 0.1.0\
 **Created:** 2026-03-29\
 **Updated:** 2026-03-29\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core, aegis-platform\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\
@@ -292,4 +292,4 @@ PRs 2 and 3 can be opened in parallel. PR 4 depends on PR 3 being merged (CI che
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0016.md
+++ b/sites/governance/src/content/docs/rfc/0016.md
@@ -10,7 +10,7 @@ description: "RFC-0016: Cross-Domain Machine Discovery Protocol"
 **Version:** 0.1.0\
 **Created:** 2026-03-30\
 **Updated:** 2026-03-30\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** All AEGIS sites (aegis-initiative, aegis-constitution, aegis-governance, aegis-docs, aegis-federation, aegis-platform)\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\

--- a/sites/governance/src/content/docs/rfc/0016.md
+++ b/sites/governance/src/content/docs/rfc/0016.md
@@ -10,7 +10,7 @@ description: "RFC-0016: Cross-Domain Machine Discovery Protocol"
 **Version:** 0.1.0\
 **Created:** 2026-03-30\
 **Updated:** 2026-03-30\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** All AEGIS sites (aegis-initiative, aegis-constitution, aegis-governance, aegis-docs, aegis-federation, aegis-platform)\
 **Target milestone:** Q2 2026\
 **Supersedes:** None\

--- a/sites/governance/src/content/docs/rfc/0017.md
+++ b/sites/governance/src/content/docs/rfc/0017.md
@@ -10,7 +10,7 @@ description: "RFC-0017: Commit Boundary and Binding Validation"
 **Version:** 0.1.0\
 **Created:** 2026-04-04\
 **Updated:** 2026-04-04\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
+**Author:** Ken Tannenbaum, AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -295,4 +295,4 @@ Make `BIND_REQUEST` optional — agents can choose to skip it for low-risk actio
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0017.md
+++ b/sites/governance/src/content/docs/rfc/0017.md
@@ -10,7 +10,7 @@ description: "RFC-0017: Commit Boundary and Binding Validation"
 **Version:** 0.1.0\
 **Created:** 2026-04-04\
 **Updated:** 2026-04-04\
-**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Operations LLC\
+**Author:** Ken Tannenbaum, AEGIS Initiative / AEGIS Initiative\
 **Repository:** aegis-governance, aegis-core\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -295,4 +295,4 @@ Make `BIND_REQUEST` optional — agents can choose to skip it for low-risk actio
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0018.md
+++ b/sites/governance/src/content/docs/rfc/0018.md
@@ -989,4 +989,4 @@ AGAP-1 is successfully implemented when:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0018.md
+++ b/sites/governance/src/content/docs/rfc/0018.md
@@ -10,7 +10,7 @@ description: "RFC-0018: Automated Governance Attestation Protocol"
 **Version:** 0.1.0\
 **Created:** 2026-04-09\
 **Updated:** 2026-04-09\
-**Author:** AEGIS Initiative, AEGIS Operations LLC\
+**Author:** AEGIS Initiative\
 **Repository:** aegis-governance\
 **Target milestone:** Q3 2026\
 **Supersedes:** None\
@@ -989,4 +989,4 @@ AGAP-1 is successfully implemented when:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0019.md
+++ b/sites/governance/src/content/docs/rfc/0019.md
@@ -173,4 +173,4 @@ implementation is deferred to the aegis-core runtime roadmap.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/rfc/0019.md
+++ b/sites/governance/src/content/docs/rfc/0019.md
@@ -173,4 +173,4 @@ implementation is deferred to the aegis-core runtime roadmap.
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*\
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/threat-model/index.md
+++ b/sites/governance/src/content/docs/threat-model/index.md
@@ -284,4 +284,4 @@ Planned extensions:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Operations LLC*
+*AEGIS Initiative — AEGIS Initiative*

--- a/sites/governance/src/content/docs/threat-model/index.md
+++ b/sites/governance/src/content/docs/threat-model/index.md
@@ -284,4 +284,4 @@ Planned extensions:
 ---
 
 *AEGIS™* | *"Capability without constraint is not intelligence"™*
-*AEGIS Initiative — AEGIS Initiative*
+*AEGIS Initiative*

--- a/sites/governance/src/content/docs/threat-model/taxonomy.md
+++ b/sites/governance/src/content/docs/threat-model/taxonomy.md
@@ -10,7 +10,7 @@ description: "ATX-1 technique taxonomy — 10 tactics, 30 techniques (39 sub-tec
 **Version:** 2.4.0\
 **Date:** 2026-05-29\
 **Status:** Active — v2.4 adds Termination Poisoning (T6003) under TA006 with 10 sub-techniques mapped to the strategies of Xu et al. (LoopTrap, arXiv:2605.05846). Severity remains removed (v2.3) for MITRE alignment.\
-**Maintainer:** AEGIS Initiative — AEGIS Operations LLC\
+**Maintainer:** AEGIS Initiative — AEGIS Initiative\
 **License:** CC-BY-SA-4.0
 
 ---

--- a/sites/governance/src/content/docs/threat-model/taxonomy.md
+++ b/sites/governance/src/content/docs/threat-model/taxonomy.md
@@ -10,7 +10,7 @@ description: "ATX-1 technique taxonomy — 10 tactics, 30 techniques (39 sub-tec
 **Version:** 2.4.0\
 **Date:** 2026-05-29\
 **Status:** Active — v2.4 adds Termination Poisoning (T6003) under TA006 with 10 sub-techniques mapped to the strategies of Xu et al. (LoopTrap, arXiv:2605.05846). Severity remains removed (v2.3) for MITRE alignment.\
-**Maintainer:** AEGIS Initiative — AEGIS Initiative\
+**Maintainer:** AEGIS Initiative\
 **License:** CC-BY-SA-4.0
 
 ---


### PR DESCRIPTION
## Description

Lands two confirmed chores that were sitting unmerged on `chore/migrate-claude-opus-4-8`, plus a fix for an artifact the first one introduced:

1. **IP entity-naming consolidation** (`c53c189`) — replace "AEGIS Operations LLC" with "AEGIS Initiative" across the repo (the aegis-governance half of the ecosystem-wide rename already applied at the workspace level).
2. **Pin release scripts to claude-sonnet-4-6** (`12ac1fc`) — `generate-release-notes.py`, `nightly-release.py` (intentional: sonnet for auto-generated release notes).
3. **Collapse duplicated bylines** — the literal substitution in (1) turned `AEGIS Initiative <sep> AEGIS Operations LLC` bylines into duplicated `AEGIS Initiative <sep> AEGIS Initiative` (106 occurrences across 95 files); collapsed each to a single `AEGIS Initiative`.

## Motivation

`main` was inconsistent — it still referenced "AEGIS Operations LLC" while the rest of the ecosystem consolidated to "AEGIS Initiative". Single brand name in public repo content also matches the public-attribution convention.

## Type of Change

- [x] Documentation update
- [ ] Reference implementation change

## Changes Made

- Org-wide `AEGIS Operations LLC` → `AEGIS Initiative` (READMEs, RFCs, AIAM specs, governance site content, NOTICE/TRADEMARKS/LICENSE-DOCS, etc.)
- Collapse 106 duplicated-name bylines to a single `AEGIS Initiative`
- Pin `sites/governance/scripts/{generate-release-notes,nightly-release}.py` to `claude-sonnet-4-6`

## Testing

- [x] Documentation builds without errors
- [x] Markdown linting passes
- [x] Spell check passes
- [x] Links are valid

## Specification Impact

- [x] No specification version impact

## Security Considerations

- [x] No security impact

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Branch follows naming convention
- [x] Commits follow Conventional Commits format
- [x] Self-review completed