### PR TITLE
fix(atx-1): correct stale "v2.3 Zenodo = 20171712" label

### DIFF
--- a/docs/atx/README.md
+++ b/docs/atx/README.md
@@ -12,12 +12,16 @@ sub-techniques, root causes, and mitigations are preserved unchanged.
 
 **Previous versions (frozen at published DOIs):**
 
-- v2.3: [10.5281/zenodo.20171712](https://doi.org/10.5281/zenodo.20171712) (2026-04-24) — severity field removed for MITRE alignment
-- v2.2: [10.5281/zenodo.19483999](https://doi.org/10.5281/zenodo.19483999) (2026-04-01)
-- v2.1: [10.5281/zenodo.19251098](https://doi.org/10.5281/zenodo.19251098) (2026-03-27)
-- v2.0: [10.5281/zenodo.19238844](https://doi.org/10.5281/zenodo.19238844)
-- v1.0 Zenodo: [10.5281/zenodo.19225676](https://doi.org/10.5281/zenodo.19225676)
-- v1.0 IEEE DataPort: [10.21227/f87b-1d57](https://dx.doi.org/10.21227/f87b-1d57)
+- v2.3: [10.21227/jr43-0571](https://doi.org/10.21227/jr43-0571) (IEEE DataPort dataset, 2026-04-24) — severity field removed for MITRE alignment
+- v2.2: [10.21227/7c9p-6150](https://doi.org/10.21227/7c9p-6150) (IEEE DataPort dataset, 2026-04-09)
+- v2.1: [10.21227/015v-9641](https://doi.org/10.21227/015v-9641) (IEEE DataPort dataset, 2026-03-30)
+- v1.0: [10.21227/f87b-1d57](https://dx.doi.org/10.21227/f87b-1d57) (IEEE DataPort dataset, 2026-03-25)
+
+> The canonical per-version ATX-1 dataset DOIs are on **IEEE DataPort** (above). The
+> `10.5281/zenodo.*` DOIs for ATX-1 are **auto-minted aegis-governance repo
+> snapshots** (concept [10.5281/zenodo.19162184](https://doi.org/10.5281/zenodo.19162184),
+> resolves to the latest), not standalone dataset records — `zenodo.20171712` is the
+> v26.5.29.2 snapshot (which contains v2.4), not a v2.3 mirror.
 
 ## Contents
 

--- a/docs/atx/v2/atx-meta.json
+++ b/docs/atx/v2/atx-meta.json
@@ -11,11 +11,13 @@
   "citation": {
     "ieee": "K. Tannenbaum, \"AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents,\" AEGIS Initiative, 2026, doi: 10.5281/zenodo.19223924.",
     "doi_preprint": "10.5281/zenodo.19223924",
-    "doi_atx1_v2.1": "10.5281/zenodo.19251098",
-    "doi_atx1_v2.2": "10.5281/zenodo.19483999",
-    "doi_atx1_v2.3": "10.5281/zenodo.20171712",
+    "dataport_atx1_v2.4": "10.21227/edxj-ka42",
     "dataport_atx1_v2.3": "10.21227/jr43-0571",
-    "dataport_atx1_v2.4": "10.21227/edxj-ka42"
+    "dataport_atx1_v2.2": "10.21227/7c9p-6150",
+    "dataport_atx1_v2.1": "10.21227/015v-9641",
+    "dataport_atx1_v1.0": "10.21227/f87b-1d57",
+    "zenodo_snapshot_concept": "10.5281/zenodo.19162184",
+    "zenodo_snapshot_note": "ATX-1 Zenodo DOIs are auto-minted aegis-governance repo snapshots (the concept DOI resolves to the latest snapshot); they are not per-version dataset records. The canonical per-version dataset DOIs are on IEEE DataPort. Note: 10.5281/zenodo.20171712 is the v26.5.29.2 repo snapshot (which contains v2.4), not a v2.3 dataset mirror."
   },
   "expected_counts": {
     "tactics": 10,

--- a/docs/atx/v2/data/atx-1-version-mapping.json
+++ b/docs/atx/v2/data/atx-1-version-mapping.json
@@ -8,9 +8,10 @@
     "v2_zenodo": "10.5281/zenodo.19238844",
     "v2.1_zenodo": "10.5281/zenodo.19251098",
     "v2.2_zenodo": "10.5281/zenodo.19483999",
-    "v2.3_zenodo": "10.5281/zenodo.20171712",
     "v2.3_ieee_dataport": "10.21227/jr43-0571",
-    "v2.4_ieee_dataport": "10.21227/edxj-ka42"
+    "v2.4_ieee_dataport": "10.21227/edxj-ka42",
+    "zenodo_snapshot_concept": "10.5281/zenodo.19162184",
+    "_zenodo_note": "Zenodo DOIs above (v1/v2/v2.1/v2.2) are auto-minted aegis-governance repo snapshots, not per-version dataset records. v2.3 has no standalone Zenodo dataset: DOI 10.5281/zenodo.20171712 (formerly recorded here as v2.3_zenodo) is the v26.5.29.2 snapshot, which contains v2.4. Cite the IEEE DataPort DOIs for datasets."
   },
   "v2.3_changes": {
     "field_removed": "severity",

--- a/sites/governance/public/atx-1/index.json
+++ b/sites/governance/public/atx-1/index.json
@@ -67,10 +67,12 @@
   "citation": {
     "ieee": "K. Tannenbaum, \"AEGIS: A Constitutional Governance Architecture for Autonomous AI Agents,\" AEGIS Initiative, 2026, doi: 10.5281/zenodo.19223924.",
     "doi_preprint": "10.5281/zenodo.19223924",
-    "doi_atx1_v2.1": "10.5281/zenodo.19251098",
-    "doi_atx1_v2.2": "10.5281/zenodo.19483999",
-    "doi_atx1_v2.3": "10.5281/zenodo.20171712",
+    "dataport_atx1_v2.4": "10.21227/edxj-ka42",
     "dataport_atx1_v2.3": "10.21227/jr43-0571",
-    "dataport_atx1_v2.4": "10.21227/edxj-ka42"
+    "dataport_atx1_v2.2": "10.21227/7c9p-6150",
+    "dataport_atx1_v2.1": "10.21227/015v-9641",
+    "dataport_atx1_v1.0": "10.21227/f87b-1d57",
+    "zenodo_snapshot_concept": "10.5281/zenodo.19162184",
+    "zenodo_snapshot_note": "ATX-1 Zenodo DOIs are auto-minted aegis-governance repo snapshots (the concept DOI resolves to the latest snapshot); they are not per-version dataset records. The canonical per-version dataset DOIs are on IEEE DataPort. Note: 10.5281/zenodo.20171712 is the v26.5.29.2 repo snapshot (which contains v2.4), not a v2.3 dataset mirror."
   }
 }

--- a/sites/governance/public/atx-1/version-mapping.json
+++ b/sites/governance/public/atx-1/version-mapping.json
@@ -8,9 +8,10 @@
     "v2_zenodo": "10.5281/zenodo.19238844",
     "v2.1_zenodo": "10.5281/zenodo.19251098",
     "v2.2_zenodo": "10.5281/zenodo.19483999",
-    "v2.3_zenodo": "10.5281/zenodo.20171712",
     "v2.3_ieee_dataport": "10.21227/jr43-0571",
-    "v2.4_ieee_dataport": "10.21227/edxj-ka42"
+    "v2.4_ieee_dataport": "10.21227/edxj-ka42",
+    "zenodo_snapshot_concept": "10.5281/zenodo.19162184",
+    "_zenodo_note": "Zenodo DOIs above (v1/v2/v2.1/v2.2) are auto-minted aegis-governance repo snapshots, not per-version dataset records. v2.3 has no standalone Zenodo dataset: DOI 10.5281/zenodo.20171712 (formerly recorded here as v2.3_zenodo) is the v26.5.29.2 snapshot, which contains v2.4. Cite the IEEE DataPort DOIs for datasets."
   },
   "v2.3_changes": {
     "field_removed": "severity",


### PR DESCRIPTION
## Description

`10.5281/zenodo.20171712` was recorded across ATX-1 metadata as the "v2.3 Zenodo mirror." It is actually the auto-minted **aegis-governance repo snapshot v26.5.29.2** (which contains ATX-1 **v2.4**), not a standalone v2.3 dataset. The v2.3 manual Zenodo deposit draft was absorbed by the 2026-06-01 monthly auto-mint. v2.3's canonical dataset DOI is the IEEE DataPort one (`10.21227/jr43-0571`).

## Motivation

ATX-1's Zenodo presence is auto-minted repo snapshots (concept `10.5281/zenodo.19162184`), not per-version dataset records — the per-version dataset DOIs live on IEEE DataPort. The metadata conflated the two, and the v2.3 entry pointed at a snapshot that has since rolled forward to v2.4.

## Type of Change

- [x] Documentation update
- [ ] Protocol or schema update

## Changes Made

- `atx-meta.json`: replace the per-version Zenodo `doi_atx1_v2.x` keys (snapshot DOIs mislabeled as dataset DOIs) with the canonical IEEE DataPort dataset DOIs (v1.0–v2.4) + the Zenodo snapshot concept + an explanatory note
- `atx-1-version-mapping.json`: drop the incorrect `v2.3_zenodo` entry; add the snapshot concept + note
- `docs/atx/README.md`: list IEEE DataPort dataset DOIs for prior versions; clarify the Zenodo DOIs are repo snapshots
- Re-synced site build outputs

## Testing

- [x] Markdown linting passes
- [x] Schema validation passes
- [x] Spell check passes
- [x] sync-atx ran clean (counts validated)

## Specification Impact

- [x] No specification version impact

## Security Considerations

- [x] No security impact

## Breaking Changes

- [x] No breaking changes