### PR TITLE
docs(outreach): record LoopTrap reply thread (both messages sent) + v2.4 DOI

### DIFF
--- a/docs/outreach/2026-05-looptrap-termination-poisoning.md
+++ b/docs/outreach/2026-05-looptrap-termination-poisoning.md
@@ -3,7 +3,7 @@
 **Date:** 2026-05-17 (response 2026-05-22)\
 **From:** Kenneth Tannenbaum, AEGIS Initiative\
 **To:** Zhibo Wang (corresponding author), Huiyu Xu (first author) — Zhejiang University *(addresses masked)*\
-**Status:** Active — ongoing exchange\
+**Status:** Replies sent (2026-05-29 endorsement ack, 2026-06-14 DOI delivery); collaboration open\
 **Response:** Received — 2026-05-22\
 **Discussion:** —
 
@@ -32,7 +32,9 @@ Huiyu Xu replied on 2026-05-22 on behalf of the LoopTrap team:
 
 - ATX-1 v2.4 adds technique **T6003 (Poison Termination Judgment)** under TA006 with sub-techniques T6003.001–T6003.010. See `changelog/2026-05-29-atx1-v2.4.md`.
 - Reference added to `REFERENCES.md` ([38]).
-- Open follow-up: whether to pair the four behavioral vulnerability dimensions (phase compliance, authority compliance, recursive susceptibility, verification tendency) with the technique as a defender's-side characterization, and whether to track the authors' forthcoming benchmark as corroborating evidence.
+- **Deposited:** ATX-1 v2.4 published to IEEE DataPort, DOI [10.21227/edxj-ka42](https://doi.org/10.21227/edxj-ka42) (2026-06-14).
+- **Correspondence:** AEGIS reply sent 2026-05-29 (thank-you + endorsement acknowledgment; flagged alignment with the authors' benchmark and shadow-progress-model defense). DOI-delivery follow-up sent 2026-06-14 with the v2.4 DataPort DOI and live taxonomy link. Full text: `housekeeping/looptrap-reply-draft-2026-05-29.md` (SENT) and `housekeeping/looptrap-followup-doi-2026-06-14.md` (SENT).
+- **Decided:** the four behavioral vulnerability dimensions (phase compliance, authority compliance, recursive susceptibility, verification tendency) are deferred to the authors' forthcoming termination-layer robustness benchmark — defender-side measurement constructs, not techniques. Intent to cite that benchmark as corroborating evidence once public stands.
 
 ---
 

--- a/docs/outreach/README.md
+++ b/docs/outreach/README.md
@@ -23,7 +23,7 @@ This directory archives outreach communications to maintain transparency in the 
 | 2026-03-13 | William Torgbi Agbemabiese | Constitutional Autonomy + AEGIS multi-layer governance | Initial outreach sent | Pending |
 | 2026-03-14 | Mattijs Moens (Sovereign Shield) | Trust decay determinism objection — GFN-1 §3.8 / RFC-0004 | Response received | Received — Discussion [#72](https://github.com/aegis-initiative/aegis-governance/discussions/72) |
 | 2026-04-14 | Microsoft Agent Governance Toolkit (AGT) team — Jack Batzner, Imran Siddique | Integration proposal — AEGIS as policy source of truth upstream of AGT enforcement runtime | Active — ongoing exchange | Received 2026-04-19; proposal requested, AEGIS reply sent 2026-04-21, proposal targeted for 2026-04-24 |
-| 2026-05-17 | Huiyu Xu, Zhibo Wang (Zhejiang University — LoopTrap authors) | Inclusion of Termination Poisoning as ATX-1 technique T6003 with attribution | Active — ongoing exchange | Received 2026-05-22 — no objections; mapping + naming endorsed; flagged benchmark + defense-architecture collaboration |
+| 2026-05-17 | Huiyu Xu, Zhibo Wang (Zhejiang University — LoopTrap authors) | Inclusion of Termination Poisoning as ATX-1 technique T6003 with attribution | Replies sent (5/29 ack, 6/14 DOI); collaboration open | Received 2026-05-22 — no objections; mapping + naming endorsed; flagged benchmark + defense-architecture collaboration |
 
 ---
 


### PR DESCRIPTION
## Description

Squares away the LoopTrap (Xu/Wang) outreach record now that both replies have been sent.

## Changes Made

- `docs/outreach/2026-05-looptrap-termination-poisoning.md`: header status → "Replies sent (2026-05-29 ack, 2026-06-14 DOI); collaboration open"; Downstream log records the v2.4 IEEE DataPort deposit (`10.21227/edxj-ka42`), both sent messages, and the deferral decision on the behavioral dimensions
- `docs/outreach/README.md`: log-table status updated to match

## Type of Change

- [x] Documentation update

## Specification Impact

- [x] No specification version impact

## Security Considerations

- [x] No security impact

## Breaking Changes

- [x] No breaking changes