### PR TITLE
fix: header version badge renders raw VERSION JSON

### DIFF
--- a/sites/governance/astro.config.mjs
+++ b/sites/governance/astro.config.mjs
@@ -1,15 +1,16 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
-import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readSiteVersion } from '@aegis-initiative/design-system/build';
 
 // Version is read from the committed VERSION file in this site
 // directory. The Header component in @aegis-initiative/design-system
 // reads `import.meta.env.AEGIS_VERSION`, which is populated here
-// before Astro/Vite loads its env files.
+// before Astro/Vite loads its env files. The VERSION file is JSON
+// ({ tag, commit, released_at }); readSiteVersion() returns the tag.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-process.env.AEGIS_VERSION = fs.readFileSync(path.resolve(__dirname, 'VERSION'), 'utf8').trim();
+process.env.AEGIS_VERSION = readSiteVersion({ cwd: __dirname });
 
 export default defineConfig({
   site: 'https://aegis-governance.com',


### PR DESCRIPTION
Same bug and fix as [aegis-federation#38](https://github.com/aegis-initiative/aegis-federation/pull/38) (canary — now verified live): the header badge displays the entire VERSION JSON object instead of the tag. Switch to `readSiteVersion()` from `@aegis-initiative/design-system/build`.

Verified with a local build: badge output is `v26.6.15`, no raw JSON in dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)