### PR TITLE
fix: month-boundary mislabel in releases index

### DIFF
--- a/sites/governance/scripts/nightly-release.py
+++ b/sites/governance/scripts/nightly-release.py
@@ -363,8 +363,11 @@ def update_monthly(year, month, tag, builds_str, release_entries, day):
     """Add release entry to monthly file."""
     file_path = f"src/content/docs/releases/{year}/{month}.md"
 
-    month_name = datetime.now(timezone.utc).strftime("%B")
-    year_full = datetime.now(timezone.utc).strftime("%Y")
+    # Derive the display name from the TARGET month, not the run date —
+    # the nightly rollup for the last day of a month runs on the 1st of
+    # the next month, which used to mislabel the monthly page.
+    month_name = datetime(2000 + int(year), int(month), 1).strftime("%B")
+    year_full = f"20{year}"
 
     entries_text = "\n".join(release_entries)
     new_section = f"""## Release / {tag}
@@ -432,8 +435,10 @@ def update_index(year, month, tag, summary):
         content = entry_pattern.sub(entry_line, content)
         print(f"Updated index entry for {base_tag}")
     else:
-        year_full = datetime.now(timezone.utc).strftime("%Y")
-        month_name = datetime.now(timezone.utc).strftime("%B")
+        # Use the TARGET month, not the run date — the rollup for the
+        # last day of a month runs on the 1st of the next month.
+        year_full = f"20{year}"
+        month_name = datetime(2000 + int(year), int(month), 1).strftime("%B")
         month_header = f"### [{month_name}](/releases/{year}/{month}/)"
         year_header = f"## {year_full}"
 

--- a/sites/governance/src/content/docs/releases/index.md
+++ b/sites/governance/src/content/docs/releases/index.md
@@ -23,12 +23,9 @@ Release notes start in April 2026 with the introduction of the auto-release pipe
 - [v26.5.13](/releases/26/5/#release--v26513) — ATX-1 v2.3 taxonomy published with official DOI on Zenodo
 - [v26.5.9](/releases/26/5/#release--v2659) — Added ecosystem identity links and enabled Labs in navigation
 
-### [May](/releases/26/4/)
-
-- [v26.4.30](/releases/26/4/#release--v26430) — Moved federation content to dedicated site with redirects
-
 ### [April](/releases/26/4/)
 
+- [v26.4.30](/releases/26/4/#release--v26430) — Moved federation content to dedicated site with redirects
 - [v26.4.29](/releases/26/4/#release--v26429) — Added sitemap index to robots.txt for better search discoverability
 - [v26.4.26](/releases/26/4/#release--v26426) — Added technical terms to spell-check dictionary
 - [v26.4.25](/releases/26/4/#release--v26425) — Moved Area of Concern lab executive summary to aegis-labs repository


### PR DESCRIPTION
Same bug as aegis-constitution#115 / aegis-docs#59: the April 30 rollup (run May 1) created a **May** section pointing at `/releases/26/4/`. Merged into April; `nightly-release.py` now derives month names from `--month`.

Local build verified: one section per month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)