### PR TITLE
docs: release notes for 2026-07-09

### DIFF
--- a/sites/governance/VERSION
+++ b/sites/governance/VERSION
@@ -1,5 +1,5 @@
 {
-  "tag": "v26.7.8",
-  "commit": "fcf6417",
-  "released_at": "2026-07-09T06:18:57Z"
+  "tag": "v26.7.9",
+  "commit": "d2c276d",
+  "released_at": "2026-07-10T06:18:04Z"
 }

--- a/sites/governance/src/content/docs/releases/26/7.md
+++ b/sites/governance/src/content/docs/releases/26/7.md
@@ -6,6 +6,14 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.7.9
+
+*Builds: d2c276d* — [Development Log →](/releases/26/7/9/)
+
+- fix: correct month labels in the releases index (#185) (d2c276d)
+
+---
+
 ## Release / v26.7.8
 
 *Builds: fcf6417* — [Development Log →](/releases/26/7/8/)

--- a/sites/governance/src/content/docs/releases/26/7/9.md
+++ b/sites/governance/src/content/docs/releases/26/7/9.md
@@ -6,6 +6,13 @@ sidebar:
   hidden: true
 ---
 
+## Release / v26.7.9
+
+*Builds: d2c276d*
+
+- fix: correct month labels in the releases index (#185) (d2c276d)
+
+---
 ## Development Log
 
 - fix: correct month labels in the releases index (#185) (d2c276d)

--- a/sites/governance/src/content/docs/releases/26/7/9.md
+++ b/sites/governance/src/content/docs/releases/26/7/9.md
@@ -1,0 +1,11 @@
+---
+title: "July 9, 2026"
+description: "Development log for July 9, 2026"
+template: doc
+sidebar:
+  hidden: true
+---
+
+## Development Log
+
+- fix: correct month labels in the releases index (#185) (d2c276d)

--- a/sites/governance/src/content/docs/releases/index.md
+++ b/sites/governance/src/content/docs/releases/index.md
@@ -12,6 +12,7 @@ Release notes start in April 2026 with the introduction of the auto-release pipe
 
 ### [July](/releases/26/7/)
 
+- [v26.7.9](/releases/26/7/#release--v2679) — Fix incorrect month labels in releases index
 - [v26.7.8](/releases/26/7/#release--v2678) — Fix VERSION JSON parsing for header badge via readSiteVersion
 
 ### [June](/releases/26/6/)


### PR DESCRIPTION
Daily release rollup — dev log, monthly summary, and index update for 2026-07-09.